### PR TITLE
OV-478-change-focus-to-alert

### DIFF
--- a/assets/js/focus-alert.js
+++ b/assets/js/focus-alert.js
@@ -4,6 +4,8 @@
 // - Move keyboard focus to the alert and ensure the page scrolls to it, overriding default hash scrolling
 // - Only run this behavior on the initial load (not on subsequent user hash navigation)
 
+const SECONDARY_FOCUS_DELAY = 250
+const INITIAL_FOCUS_DELAY = 50
 ;(function () {
   function focusAlertOnLoad() {
     var alertEl = document.querySelector('.moj-alert[role="alert"]')
@@ -48,8 +50,21 @@
 
     // Schedule the focus/scroll to run after DOMContentLoaded so it overrides any
     // earlier hash-based scrolling. Run twice with small delays to be robust.
-    setTimeout(focusAndScroll, 50)
-    setTimeout(focusAndScroll, 250)
+    var hash = window.location.hash
+    var shouldOverrideHash = true
+    if (hash) {
+      var id = decodeURIComponent(hash.slice(1))
+      try {
+        var targetEl = document.getElementById(id) || document.querySelector('[name="' + id.replace(/"/g, '\\"') + '"]')
+        if (targetEl) shouldOverrideHash = false
+      } catch (e) {
+        // ignore selector errors and fall back to overriding
+      }
+    }
+    if (shouldOverrideHash) {
+      setTimeout(focusAndScroll, INITIAL_FOCUS_DELAY)
+      setTimeout(focusAndScroll, SECONDARY_FOCUS_DELAY)
+    }
   }
 
   if (document.readyState === 'loading') {

--- a/assets/js/focus-alert.js
+++ b/assets/js/focus-alert.js
@@ -6,7 +6,7 @@
 
 ;(function () {
   function focusAlertOnLoad() {
-    var alertEl = document.querySelector('.moj-alert[role="alert"], .moj-alert')
+    var alertEl = document.querySelector('.moj-alert[role="alert"]')
     if (!alertEl) return
 
     // Ensure the alert is focusable but not in the tab order

--- a/assets/js/focus-alert.js
+++ b/assets/js/focus-alert.js
@@ -16,9 +16,14 @@
       // ignore
     }
 
-    // Ensure polite live region if not already present
+    // Ensure appropriate live region if not already present
     if (!alertEl.hasAttribute('aria-live')) {
-      alertEl.setAttribute('aria-live', 'polite')
+      // For role="alert", rely on the default assertive politeness.
+      // For other alerts, default to a polite live region.
+      var role = alertEl.getAttribute('role')
+      if (role !== 'alert') {
+        alertEl.setAttribute('aria-live', 'polite')
+      }
     }
 
     // Function that scrolls to and focuses the alert. Run twice with delays to

--- a/assets/js/focus-alert.js
+++ b/assets/js/focus-alert.js
@@ -1,0 +1,56 @@
+// Focus the page alert (if present) on initial page load to improve accessibility.
+// Behavior requirements:
+// - If a .moj-alert[role="alert"] exists on page load, make it focusable but not tabbable (tabindex=-1)
+// - Move keyboard focus to the alert and ensure the page scrolls to it, overriding default hash scrolling
+// - Only run this behavior on the initial load (not on subsequent user hash navigation)
+
+;(function () {
+  function focusAlertOnLoad() {
+    var alertEl = document.querySelector('.moj-alert[role="alert"], .moj-alert')
+    if (!alertEl) return
+
+    // Ensure the alert is focusable but not in the tab order
+    try {
+      alertEl.setAttribute('tabindex', '-1')
+    } catch (e) {
+      // ignore
+    }
+
+    // Ensure polite live region if not already present
+    if (!alertEl.hasAttribute('aria-live')) {
+      alertEl.setAttribute('aria-live', 'polite')
+    }
+
+    // Function that scrolls to and focuses the alert. Run twice with delays to
+    // reliably override browser hash scrolling behavior on different browsers.
+    var focusAndScroll = function () {
+      try {
+        alertEl.scrollIntoView({ behavior: 'auto', block: 'start' })
+      } catch (e) {
+        // Fallback for older browsers
+        var top = alertEl.getBoundingClientRect().top + window.pageYOffset
+        window.scrollTo(0, top)
+      }
+
+      try {
+        // Focus without causing additional scroll (we've already scrolled)
+        alertEl.focus({ preventScroll: true })
+      } catch (e) {
+        // Some browsers don't support options; fallback
+        alertEl.focus()
+      }
+    }
+
+    // Schedule the focus/scroll to run after DOMContentLoaded so it overrides any
+    // earlier hash-based scrolling. Run twice with small delays to be robust.
+    setTimeout(focusAndScroll, 50)
+    setTimeout(focusAndScroll, 250)
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', focusAlertOnLoad)
+  } else {
+    // If the script was loaded after DOMContentLoaded
+    setTimeout(focusAlertOnLoad, 0)
+  }
+})()

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -3,6 +3,7 @@ import * as mojFrontend from '@ministryofjustice/frontend'
 import Card from './card'
 import { nodeListForEach } from './utils'
 import './application-insights-setup'
+import './focus-alert'
 
 govukFrontend.initAll()
 mojFrontend.initAll()

--- a/integration_tests/specs/addLocation.spec.ts
+++ b/integration_tests/specs/addLocation.spec.ts
@@ -70,6 +70,10 @@ test.describe('Admin: Add a new location', () => {
     // After submit ensure we've returned to locations page
     await expect(page).toHaveURL('/admin/time-slot/1/locations')
 
+    // The page renders a success alert; client-side behaviour should move focus to that alert on page load
+    // Assert the alert receives focus to cover accessibility regression risk
+    await expect(page.getByRole('alert')).toBeFocused()
+
     // Verify wiremock saw the POST request
     const reqs = await getMatchingRequests({ method: 'POST', url: '/official-visits-api/admin/time-slot/1/visit-slot' })
     // Expect at least one request matching


### PR DESCRIPTION
Add a new accessibility enhancement for page alerts and ensure the new behaviour is loaded with the rest of the frontend JavaScript. The main focus is to automatically move keyboard focus to alert banners on initial page load, improving accessibility for screen reader and keyboard users.


test evidence:

https://github.com/user-attachments/assets/91499650-e54d-42b1-a272-7a46cfb16871

