### PR TITLE
OV-502 bringing the .npmrc file inline with the template project to harden security.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -9,5 +9,11 @@ save-exact = true
 # Fail if trying to use incorrect version of npm
 engine-strict = true
 
-# Show any output of scripts in the console 
+# Show any output of scripts in the console
 foreground-scripts = true
+
+# Wait a minimum of 7 days before allowing a package to be released, this is to allow time for any issues to be discovered and fixed before the package is released
+min-release-age = 7
+
+# Don't allow git dependencies see here. These can allow malicious actors to alias common executables with nefarious versions
+allow-git = none


### PR DESCRIPTION
Bring the service inline with the latest template changes for hardened service security with regards to the .npmrc file restrictions.

See the associated template changes [here](https://github.com/ministryofjustice/hmpps-template-typescript/pull/706).