### PR TITLE
OV-531: Fix feComponents not rendering when POST requests display html content

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -34,6 +34,7 @@ declare module 'express-serve-static-core' {
     addSuccessMessage?(heading: string, message?: string): void
     addValidationError?(message: string, field?: string): void
     validationFailed?(message?: string, field?: string): void
+    alertValidationError?(errors: Record<string, boolean>, redirectUrl?: string): void
   }
 }
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -42,7 +42,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpFlash())
   app.use(setUpCurrentUser())
 
-  app.use(
+  app.get(
     /(.*)/,
     getFrontendComponents({
       requestOptions: { includeSharedData: true },

--- a/server/app.ts
+++ b/server/app.ts
@@ -42,7 +42,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpFlash())
   app.use(setUpCurrentUser())
 
-  app.get(
+  app.use(
     /(.*)/,
     getFrontendComponents({
       requestOptions: { includeSharedData: true },

--- a/server/middleware/setUpFlash.ts
+++ b/server/middleware/setUpFlash.ts
@@ -31,6 +31,11 @@ export default function setUpFlash(): Router {
       res.redirect(redirectUrl || req.get('Referrer') || '/')
     }
 
+    res.alertValidationError = (errors: Record<string, boolean>, redirectUrl?: string): void => {
+      req.flash('alertErrors', JSON.stringify(errors))
+      res.redirect(redirectUrl || req.get('Referrer') || '/')
+    }
+
     res.addSuccessMessage = (heading: string, message?: string) => {
       req.flash('successMessage', JSON.stringify({ heading, message }))
     }

--- a/server/routes/journeys/manage/visit/handlers/assistanceRequiredHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/assistanceRequiredHandler.ts
@@ -16,7 +16,7 @@ export default class AssistanceRequiredHandler implements PageHandler {
 
   BODY = schema
 
-  public GET = async (req: Request, res: Response, _next?: NextFunction, errors: Record<string, boolean> = {}) => {
+  public GET = async (req: Request, res: Response, _next?: NextFunction) => {
     const contacts = [
       ...req.session.journey.officialVisit.officialVisitors,
       ...(req.session.journey.officialVisit.socialVisitors || []),
@@ -24,6 +24,9 @@ export default class AssistanceRequiredHandler implements PageHandler {
 
     const { officialVisit } = req.session.journey
     const changeThisPage = req.session.journey.amendVisit?.changePage === 'assistance-required'
+
+    const rawErrors = req.flash('alertErrors')[0]
+    const errors = rawErrors ? JSON.parse(rawErrors) : {}
 
     res.render('pages/manage/assistanceRequired', {
       contacts,
@@ -50,7 +53,7 @@ export default class AssistanceRequiredHandler implements PageHandler {
     if (res.locals.mode === 'amend' && (changeThisPage || !equipmentPageEnabled(officialVisit))) {
       const errors = await cyaGuard(req, res, this.officialVisitsService)
       if (Object.keys(errors).length > 0) {
-        return this.GET(req, res, undefined, errors)
+        return res.alertValidationError(errors)
       }
 
       const allVisitors = [...(officialVisit.officialVisitors || []), ...(officialVisit.socialVisitors || [])]

--- a/server/routes/journeys/manage/visit/handlers/checkYourAnswersHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/checkYourAnswersHandler.test.ts
@@ -6,6 +6,7 @@ import AuditService, { Page } from '../../../../../services/auditService'
 import PrisonerService from '../../../../../services/prisonerService'
 import OfficialVisitsService from '../../../../../services/officialVisitsService'
 import { getPageHeader, getValueByKey } from '../../../../testutils/cheerio'
+import { expectAlertErrors } from '../../../../testutils/expectErrorMessage'
 import { Journey } from '../../../../../@types/express'
 import { OfficialVisitJourney } from '../journey'
 import { AvailableSlot, RestrictionSummary } from '../../../../../@types/officialVisitsApi/types'
@@ -346,14 +347,14 @@ describe('check your answers handler', () => {
 
       return request(app)
         .post(URL)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Duplicate visitors selected')
-          expect($('.moj-alert__content').text()).toContain('You have selected the same contact more than once')
-          expect($('.moj-alert__content').text()).toContain('Remove duplicate visitors')
-        })
+        .set('Referer', URL)
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasDuplicateContactIds: true,
+          }),
+        )
     })
 
     it('should display duplicate contact error when same contact appears twice in official visitors', () => {
@@ -377,14 +378,14 @@ describe('check your answers handler', () => {
 
       return request(app)
         .post(URL)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Duplicate visitors selected')
-          expect($('.moj-alert__content').text()).toContain('You have selected the same contact more than once')
-          expect($('.moj-alert__content').text()).toContain('Remove duplicate visitors')
-        })
+        .set('Referer', URL)
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasDuplicateContactIds: true,
+          }),
+        )
     })
 
     it('should display prisoner overlap error on GET when prisoner has conflicting visit', () => {
@@ -396,13 +397,14 @@ describe('check your answers handler', () => {
 
       return request(app)
         .post(URL)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('This prisoner already has a visit booked')
-          expect($('.moj-alert__content').text()).toContain('The prisoner has another visit booked at this time')
-        })
+        .set('Referer', URL)
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasPrisonerOverlap: true,
+          }),
+        )
     })
 
     it('should display visitor overlap error on GET when visitor has conflicting visit', () => {
@@ -419,13 +421,14 @@ describe('check your answers handler', () => {
 
       return request(app)
         .post(URL)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('A visitor already has a visit booked')
-          expect($('.moj-alert__content').text()).toContain('A visitor has another visit booked at this time')
-        })
+        .set('Referer', URL)
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasVisitorOverlap: true,
+          }),
+        )
     })
 
     it('should display both prisoner and visitor overlap errors on GET when both have conflicts', () => {
@@ -442,13 +445,15 @@ describe('check your answers handler', () => {
 
       return request(app)
         .post(URL)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(2)
-          expect($('.moj-alert__heading').eq(0).text()).toContain('This prisoner already has a visit booked')
-          expect($('.moj-alert__heading').eq(1).text()).toContain('A visitor already has a visit booked')
-        })
+        .set('Referer', URL)
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasPrisonerOverlap: true,
+            hasVisitorOverlap: true,
+          }),
+        )
     })
   })
 
@@ -464,16 +469,15 @@ describe('check your answers handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send()
-        .expect(200)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Capacity for visit slot selected is exceeded')
-          expect($('.moj-alert__content').text()).toContain('The visit slot has exceeded maximum visitor capacity')
-          expect($('.moj-alert__content a').text()).toContain('Choose another time slot')
-          expect($('.moj-alert__content a').attr('href')).toBe('time-slot')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            noCapacity: true,
+          }),
+        )
 
       expect(officialVisitsService.createVisit).not.toHaveBeenCalled()
     })
@@ -511,16 +515,15 @@ describe('check your answers handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send()
-        .expect(200)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Capacity for visit slot selected is exceeded')
-          expect($('.moj-alert__content').text()).toContain('The visit slot has exceeded maximum visitor capacity')
-          expect($('.moj-alert__content a').text()).toContain('Choose another time slot')
-          expect($('.moj-alert__content a').attr('href')).toBe('time-slot')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            noCapacity: true,
+          }),
+        )
 
       expect(officialVisitsService.createVisit).not.toHaveBeenCalled()
     })
@@ -542,16 +545,15 @@ describe('check your answers handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send()
-        .expect(200)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Capacity for visit slot selected is exceeded')
-          expect($('.moj-alert__content').text()).toContain('The visit slot has exceeded maximum visitor capacity')
-          expect($('.moj-alert__content a').text()).toContain('Choose another time slot')
-          expect($('.moj-alert__content a').attr('href')).toBe('time-slot')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            noCapacity: true,
+          }),
+        )
 
       expect(officialVisitsService.createVisit).not.toHaveBeenCalled()
     })
@@ -586,15 +588,15 @@ describe('check your answers handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send()
-        .expect(200)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Duplicate visitors selected')
-          expect($('.moj-alert__content').text()).toContain('You have selected the same contact more than once')
-          expect($('.moj-alert__content').text()).toContain('Remove duplicate visitors')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasDuplicateContactIds: true,
+          }),
+        )
 
       expect(officialVisitsService.createVisit).not.toHaveBeenCalled()
     })
@@ -620,15 +622,15 @@ describe('check your answers handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send()
-        .expect(200)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Duplicate visitors selected')
-          expect($('.moj-alert__content').text()).toContain('You have selected the same contact more than once')
-          expect($('.moj-alert__content').text()).toContain('Remove duplicate visitors')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasDuplicateContactIds: true,
+          }),
+        )
 
       expect(officialVisitsService.createVisit).not.toHaveBeenCalled()
     })
@@ -642,14 +644,15 @@ describe('check your answers handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send()
-        .expect(200)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('This prisoner already has a visit booked')
-          expect($('.moj-alert__content').text()).toContain('The prisoner has another visit booked at this time')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasPrisonerOverlap: true,
+          }),
+        )
 
       expect(officialVisitsService.createVisit).not.toHaveBeenCalled()
     })
@@ -668,14 +671,15 @@ describe('check your answers handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send()
-        .expect(200)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('A visitor already has a visit booked')
-          expect($('.moj-alert__content').text()).toContain('A visitor has another visit booked at this time')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasVisitorOverlap: true,
+          }),
+        )
 
       expect(officialVisitsService.createVisit).not.toHaveBeenCalled()
     })
@@ -694,14 +698,16 @@ describe('check your answers handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send()
-        .expect(200)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(2)
-          expect($('.moj-alert__heading').eq(0).text()).toContain('This prisoner already has a visit booked')
-          expect($('.moj-alert__heading').eq(1).text()).toContain('A visitor already has a visit booked')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasPrisonerOverlap: true,
+            hasVisitorOverlap: true,
+          }),
+        )
 
       expect(officialVisitsService.createVisit).not.toHaveBeenCalled()
     })

--- a/server/routes/journeys/manage/visit/handlers/checkYourAnswersHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/checkYourAnswersHandler.ts
@@ -9,9 +9,12 @@ export default class CheckYourAnswersHandler implements PageHandler {
 
   constructor(private readonly officialVisitsService: OfficialVisitsService) {}
 
-  public GET = async (req: Request, res: Response, _next?: NextFunction, errors: Record<string, boolean> = {}) => {
+  public GET = async (req: Request, res: Response, _next?: NextFunction) => {
     const { officialVisit } = req.session.journey
     const { prisoner } = officialVisit
+
+    const rawErrors = req.flash('alertErrors')[0]
+    const errors = rawErrors ? JSON.parse(rawErrors) : {}
 
     req.session.journey.reachedCheckAnswers = true
     return res.render('pages/manage/checkYourAnswers', {
@@ -30,7 +33,7 @@ export default class CheckYourAnswersHandler implements PageHandler {
     const errors = await cyaGuard(req, res, this.officialVisitsService)
 
     if (Object.keys(errors).length > 0) {
-      return this.GET(req, res, undefined, errors)
+      return res.alertValidationError(errors)
     }
 
     if (mode === 'create') {

--- a/server/routes/journeys/manage/visit/handlers/equipmentHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/equipmentHandler.ts
@@ -12,11 +12,14 @@ export default class EquipmentHandler implements PageHandler {
 
   constructor(private readonly officialVisitsService: OfficialVisitsService) {}
 
-  public GET = async (req: Request, res: Response, _next?: NextFunction, errors: Record<string, boolean> = {}) => {
+  public GET = async (req: Request, res: Response, _next?: NextFunction) => {
     const contacts = [
       ...req.session.journey.officialVisit.officialVisitors,
       ...(req.session.journey.officialVisit.socialVisitors || []),
     ].filter(o => o.contactId)
+
+    const rawErrors = req.flash('alertErrors')[0]
+    const errors = rawErrors ? JSON.parse(rawErrors) : {}
 
     res.render('pages/manage/equipment', {
       contacts,
@@ -39,7 +42,7 @@ export default class EquipmentHandler implements PageHandler {
       const errors = await cyaGuard(req, res, this.officialVisitsService)
 
       if (Object.keys(errors).length > 0) {
-        return this.GET(req, res, undefined, errors)
+        return res.alertValidationError(errors)
       }
       const allVisitors = [...officialVisit.officialVisitors, ...(officialVisit.socialVisitors || [])]
       const officialVisitors: OfficialVisitor[] = allVisitors.map(visitor => ({

--- a/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.test.ts
@@ -15,7 +15,7 @@ import {
 import { Journey } from '../../../../../@types/express'
 import { getJourneySession } from '../../../../testutils/testUtilRoute'
 import { mockOfficialVisitors, mockPrisonerRestrictions, mockPrisoner } from '../../../../../testutils/mocks'
-import { expectErrorMessages, expectNoErrorMessages } from '../../../../testutils/expectErrorMessage'
+import { expectErrorMessages, expectNoErrorMessages, expectAlertErrors } from '../../../../testutils/expectErrorMessage'
 import { convertToTitleCase, formatDate } from '../../../../../utils/utils'
 import config from '../../../../../config'
 import { JourneyVisitor, OfficialVisitJourney } from '../journey'
@@ -436,6 +436,7 @@ describe('Select official visitors', () => {
         relationshipToPrisonerCode: 'SOL',
         relationshipToPrisonerDescription: 'Solicitor',
       }
+      const amendUrl = `/manage/amend/123/${journeyId()}/select-official-visitors`
 
       appSetup({
         officialVisit: {
@@ -452,17 +453,16 @@ describe('Select official visitors', () => {
       })
 
       return request(app)
-        .post(`/manage/amend/123/${journeyId()}/select-official-visitors`)
+        .post(amendUrl)
+        .set('Referer', amendUrl)
         .send({})
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('You cannot remove all visitors from an official visit')
-          expect($('.moj-alert__content').text()).toContain('A visit must have at least one official visitor')
-          expect($('.moj-alert__content a').attr('href')).toContain('/view/visit/123/cancel')
-        })
+        .expect(302)
+        .expect('location', amendUrl)
+        .expect(() =>
+          expectAlertErrors({
+            empty: true,
+          }),
+        )
     })
 
     it('should accept the selection of one official visitor and redirect to social visitors page', async () => {
@@ -566,16 +566,15 @@ describe('Select official visitors', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send({ selected: ['101-SOL', '101-JUD'] })
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          // Verify the duplicate contact error alert is displayed
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Duplicate visitors selected')
-          expect($('.moj-alert__content').text()).toContain('You have selected the same contact more than once')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasDuplicateContactIds: true,
+          }),
+        )
 
       // Verify the visitors are saved to session but validation error prevents progression
       const journeySession = await getJourneySession(app, 'officialVisit')

--- a/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.ts
@@ -42,7 +42,7 @@ export default class SelectOfficialVisitorsHandler implements PageHandler {
     )
   }
 
-  public GET = async (req: Request, res: Response, _next?: NextFunction, errors: Record<string, boolean> = {}) => {
+  public GET = async (req: Request, res: Response, _next?: NextFunction) => {
     // TODO: Assume a middleware caseload access check earlier (user v. prisoner's location)
     const { prisonerNumber } = req.session.journey.officialVisit.prisoner
 
@@ -54,6 +54,9 @@ export default class SelectOfficialVisitorsHandler implements PageHandler {
       res.locals.formResponses?.selected ||
       journeyVisitors?.map(v => `${v.contactId}-${v.relationshipToPrisonerCode}`) ||
       []
+
+    const rawErrors = req.flash('alertErrors')[0]
+    const errors = rawErrors ? JSON.parse(rawErrors) : {}
 
     // Show the list and prefill the selected checkboxes for official visitors
     const previousDate = req.session.journey.officialVisit?.selectedTimeSlot?.visitDate
@@ -74,7 +77,7 @@ export default class SelectOfficialVisitorsHandler implements PageHandler {
     const selected: string[] = Array.isArray(req.body.selected) ? req.body.selected : []
 
     if (!selected.length) {
-      return this.GET(req, res, undefined, { empty: true })
+      return res.alertValidationError({ empty: true })
     }
 
     const journeyVisitors = req.session.journey.officialVisit.officialVisitors || []
@@ -98,7 +101,7 @@ export default class SelectOfficialVisitorsHandler implements PageHandler {
     const errors = await cyaGuard(req, res, this.officialVisitsService)
 
     if (Object.keys(errors).length > 0) {
-      return this.GET(req, res, undefined, errors)
+      return res.alertValidationError(errors)
     }
 
     return res.redirect(socialVisitorsPageEnabled(req) ? `select-social-visitors` : `assistance-required`)

--- a/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.test.ts
@@ -16,7 +16,7 @@ import { Journey } from '../../../../../@types/express'
 import { JourneyVisitor } from '../journey'
 import { getJourneySession } from '../../../../testutils/testUtilRoute'
 import { mockSocialVisitors, mockPrisonerRestrictions, mockPrisoner } from '../../../../../testutils/mocks'
-import { expectNoErrorMessages } from '../../../../testutils/expectErrorMessage'
+import { expectNoErrorMessages, expectAlertErrors } from '../../../../testutils/expectErrorMessage'
 import { convertToTitleCase, formatDate } from '../../../../../utils/utils'
 
 jest.mock('../../../../../services/auditService')
@@ -356,16 +356,15 @@ describe('Select social visitors', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send({ selected: ['201-BRO', '201-FRI'] })
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          // Verify the duplicate contact error alert is displayed
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('Duplicate visitors selected')
-          expect($('.moj-alert__content').text()).toContain('You have selected the same contact more than once')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasDuplicateContactIds: true,
+          }),
+        )
 
       // Verify the visitors are saved to session but validation error prevents progression
       const journeySession = await getJourneySession(app, 'officialVisit')

--- a/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.ts
@@ -28,7 +28,7 @@ export default class SelectSocialVisitorsHandler implements PageHandler {
     )
   }
 
-  public GET = async (req: Request, res: Response, _next?: NextFunction, errors: Record<string, boolean> = {}) => {
+  public GET = async (req: Request, res: Response, _next?: NextFunction) => {
     // TODO: Assume a middleware caseload access check earlier (user v. prisoner's location)
     const { prisonerNumber } = req.session.journey.officialVisit.prisoner
     const journeyVisitors = req.session.journey.officialVisit.socialVisitors || []
@@ -39,6 +39,9 @@ export default class SelectSocialVisitorsHandler implements PageHandler {
       res.locals.formResponses?.selected ||
       journeyVisitors?.map(v => `${v.contactId}-${v.relationshipToPrisonerCode}`) ||
       []
+
+    const rawErrors = req.flash('alertErrors')[0]
+    const errors = rawErrors ? JSON.parse(rawErrors) : {}
 
     // Show the list and prefill the checkboxes for the selected social visitors
     res.render('pages/manage/selectSocialVisitors', {
@@ -76,7 +79,7 @@ export default class SelectSocialVisitorsHandler implements PageHandler {
     const errors = await cyaGuard(req as Request, res, this.officialVisitsService)
 
     if (Object.keys(errors).length > 0) {
-      return this.GET(req as Request, res, undefined, errors)
+      return res.alertValidationError(errors)
     }
 
     req.session.journey.officialVisit.socialVisitorsPageCompleted = true

--- a/server/routes/journeys/manage/visit/handlers/timeSlotHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/timeSlotHandler.test.ts
@@ -13,6 +13,7 @@ import {
   expectErrorMessages,
   expectFlashMessage,
   expectNoErrorMessages,
+  expectAlertErrors,
 } from '../../../../testutils/expectErrorMessage'
 import { Journey } from '../../../../../@types/express'
 import { OfficialVisitJourney } from '../journey'
@@ -288,14 +289,15 @@ describe('Time slot handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send({ visitSlot: '1' })
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          // Verify the duplicate contact error alert is displayed
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('This prisoner already has a visit booked')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasPrisonerOverlap: true,
+          }),
+        )
     })
 
     it('should redirect back to time slot page if there are visitor overlaps', async () => {
@@ -312,15 +314,15 @@ describe('Time slot handler', () => {
 
       await request(app)
         .post(URL)
+        .set('Referer', URL)
         .send({ visitSlot: '1' })
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          // Verify the duplicate contact error alert is displayed
-          expect($('.moj-alert--error').length).toBe(1)
-          expect($('.moj-alert__heading').text()).toContain('A visitor already has a visit booked')
-        })
+        .expect(302)
+        .expect('location', URL)
+        .expect(() =>
+          expectAlertErrors({
+            hasVisitorOverlap: true,
+          }),
+        )
     })
 
     it('should accept a valid time slot in amend mode', async () => {

--- a/server/routes/journeys/manage/visit/handlers/timeSlotHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/timeSlotHandler.ts
@@ -18,7 +18,7 @@ export default class TimeSlotHandler implements PageHandler {
 
   BODY = schema
 
-  public GET = async (req: Request, res: Response, _next?: NextFunction, errors: Record<string, boolean> = {}) => {
+  public GET = async (req: Request, res: Response, _next?: NextFunction) => {
     const { date = '' } = req.query
     const selectedDate = getParsedDateFromQueryString(date.toString(), new Date())
     const { weekOfDates, previousWeek, nextWeek } = getWeekOfDatesStartingMonday(selectedDate)
@@ -46,6 +46,9 @@ export default class TimeSlotHandler implements PageHandler {
       user,
     )
 
+    const rawErrors = req.flash('alertErrors')[0]
+    const errors = rawErrors ? JSON.parse(rawErrors) : {}
+
     res.render('pages/manage/timeSlot', {
       today: new Date().toISOString().substring(0, 10),
       selectedDate,
@@ -72,7 +75,7 @@ export default class TimeSlotHandler implements PageHandler {
     const errors = await cyaGuard(req, res, this.officialVisitsService)
 
     if (Object.keys(errors).length > 0) {
-      return this.GET(req, res, undefined, errors)
+      return res.alertValidationError(errors)
     }
 
     if (res.locals.mode === 'amend') {

--- a/server/routes/testutils/expectErrorMessage.ts
+++ b/server/routes/testutils/expectErrorMessage.ts
@@ -14,3 +14,7 @@ export function expectNoErrorMessages() {
 export function expectFlashMessage(name: string, message: string, nth: number = 1) {
   expect(flashProvider).toHaveBeenNthCalledWith(nth, name, message)
 }
+
+export function expectAlertErrors(errors: Record<string, boolean>, nth: number = 1) {
+  expect(flashProvider).toHaveBeenNthCalledWith(nth, 'alertErrors', JSON.stringify(errors))
+}


### PR DESCRIPTION
Alert errors previously used a pattern of calling `this.GET` on POST when an alert validation failed. Frontend components are not pulled down on POST requests thus were missing when we displayed the page. 

Original solution was changing app so that it pulled on GET and POST, but there are many POSTS we don't care about, so we're now using `req.flash` in a similar way to standard validation errors but for alert errors instead as these display differently