### PR TITLE
OV-561: Inset text updates for unauthorised users

### DIFF
--- a/server/routes/journeys/manage/visit/handlers/amendVisitLandingHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/amendVisitLandingHandler.test.ts
@@ -355,7 +355,7 @@ describe('Search for an official visit', () => {
 
       const res = await request(app).get(URL)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('does not have a recorded relationship with the prisoner')
+      expect(res.text).toContain('a visitor does not have a recorded relationship with the prisoner')
       expect(res.text).toContain('govuk-inset-text')
     })
 
@@ -365,7 +365,7 @@ describe('Search for an official visit', () => {
 
       const res = await request(app).get(URL)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('a visitor is not an approved contact')
     })
 
     it('should show inset text when visitor is a social visitor for prison without social visits enabled', async () => {
@@ -377,7 +377,7 @@ describe('Search for an official visit', () => {
 
       const res = await request(app).get(URL)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain('social visitors cannot join official visits')
     })
 
     it('should show MOJ badge "NO RECORDED RELATIONSHIP" on visitor card when contact not found', async () => {

--- a/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.test.ts
@@ -18,6 +18,7 @@ import { mockOfficialVisitors, mockPrisonerRestrictions, mockPrisoner } from '..
 import { expectErrorMessages, expectNoErrorMessages, expectAlertErrors } from '../../../../testutils/expectErrorMessage'
 import { convertToTitleCase, formatDate } from '../../../../../utils/utils'
 import config from '../../../../../config'
+import { AuthorisedRoles } from '../../../../../middleware/populateUserPermissions'
 import { JourneyVisitor, OfficialVisitJourney } from '../journey'
 
 jest.mock('../../../../../services/auditService')
@@ -52,11 +53,12 @@ const appSetup = (
       visitType: 'IN_PERSON',
     } as OfficialVisitJourney,
   },
+  userRoles: AuthorisedRoles[] = user.userRoles as AuthorisedRoles[],
 ) => {
   config.featureToggles.allowSocialVisitorsPrisons = 'MDI'
   app = appWithAllRoutes({
     services: { auditService, prisonerService, officialVisitsService },
-    userSupplier: () => user,
+    userSupplier: () => ({ ...user, userRoles }),
     journeySessionSupplier: () => journeySession as Journey,
   })
 }
@@ -491,6 +493,99 @@ describe('Select official visitors', () => {
             correlationId: expect.any(String),
           })
         })
+    })
+
+    it('should show correct inset text when user has both authoriser and manage roles', async () => {
+      const notApprovedVisitor = {
+        ...mockOfficialVisitors[2],
+        prisonerContactId: 104,
+        contactId: 104,
+        relationshipToPrisonerCode: 'JUD',
+        relationshipToPrisonerDescription: 'Judge',
+        isApprovedVisitor: false,
+      }
+
+      appSetup(
+        {
+          officialVisit: {
+            prisoner: {
+              ...mockPrisoner,
+              restrictions: mockPrisonerRestrictions,
+            },
+            prisonCode: 'MDI',
+            availableSlots: [{ timeSlotId: 1, visitSlotId: 1 }],
+            selectedTimeSlot: {
+              timeSlotId: 1,
+              visitSlotId: 1,
+              visitDate: '2037-01-26',
+              startTime: '13:30',
+              endTime: '16:00',
+              availableVideoSessions: 2,
+              availableAdults: 3,
+              availableGroups: 2,
+            },
+            officialVisitors: [notApprovedVisitor],
+            socialVisitors: [],
+          } as OfficialVisitJourney,
+        },
+        [AuthorisedRoles.VIEW, AuthorisedRoles.CONTACTS_AUTHORISER, AuthorisedRoles.MANAGE],
+      )
+
+      officialVisitsService.getAllOfficialContacts.mockResolvedValue([...mockOfficialVisitors, notApprovedVisitor])
+
+      const res = await request(app).get(`/manage/amend/1/${journeyId()}/select-official-visitors?change=true`)
+      expect(res.text).toContain('Some visitor details need updating')
+      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain(
+        "You can update visitor details in the prisoner's contact record or remove visitors from this visit.",
+      )
+    })
+
+    it('should show correct inset text when user has only manage role', async () => {
+      const notApprovedVisitor = {
+        ...mockOfficialVisitors[2],
+        prisonerContactId: 104,
+        contactId: 104,
+        relationshipToPrisonerCode: 'JUD',
+        relationshipToPrisonerDescription: 'Judge',
+        isApprovedVisitor: false,
+      }
+
+      appSetup(
+        {
+          officialVisit: {
+            prisoner: {
+              ...mockPrisoner,
+              restrictions: mockPrisonerRestrictions,
+            },
+            prisonCode: 'MDI',
+            availableSlots: [{ timeSlotId: 1, visitSlotId: 1 }],
+            selectedTimeSlot: {
+              timeSlotId: 1,
+              visitSlotId: 1,
+              visitDate: '2037-01-26',
+              startTime: '13:30',
+              endTime: '16:00',
+              availableVideoSessions: 2,
+              availableAdults: 3,
+              availableGroups: 2,
+            },
+            officialVisitors: [notApprovedVisitor],
+            socialVisitors: [],
+          } as OfficialVisitJourney,
+        },
+        [AuthorisedRoles.VIEW, AuthorisedRoles.MANAGE],
+      )
+
+      officialVisitsService.getAllOfficialContacts.mockResolvedValue([...mockOfficialVisitors, notApprovedVisitor])
+
+      const res = await request(app).get(`/manage/amend/1/${journeyId()}/select-official-visitors?change=true`)
+      expect(res.text).toContain('Some visitor details need updating')
+      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('You can remove visitors from this visit.')
+      expect(res.text).toContain(
+        "You'll need the Contacts Authoriser role to update visitor details in the prisoner's contact record.",
+      )
     })
   })
 

--- a/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.test.ts
@@ -367,8 +367,8 @@ describe('Select official visitors', () => {
 
           // Check inset text is displayed with correct bullet points
           expect(res.text).toContain('Some visitor details need updating')
-          expect(res.text).toContain('is not an approved contact')
-          expect(res.text).toContain('does not have a recorded relationship with the prisoner')
+          expect(res.text).toContain('a visitor is not an approved contact')
+          expect(res.text).toContain('a visitor does not have a recorded relationship with the prisoner')
 
           // Check MOJ badges are displayed for the two visitors with issues
           expect(res.text).toContain('CONTACT NOT APPROVED')
@@ -535,7 +535,7 @@ describe('Select official visitors', () => {
 
       const res = await request(app).get(`/manage/amend/1/${journeyId()}/select-official-visitors?change=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('a visitor is not an approved contact')
       expect(res.text).toContain(
         "You can update visitor details in the prisoner's contact record or remove visitors from this visit.",
       )
@@ -581,7 +581,7 @@ describe('Select official visitors', () => {
 
       const res = await request(app).get(`/manage/amend/1/${journeyId()}/select-official-visitors?change=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('a visitor is not an approved contact')
       expect(res.text).toContain('You can remove visitors from this visit.')
       expect(res.text).toContain(
         "You'll need the Contacts Authoriser role to update visitor details in the prisoner's contact record.",

--- a/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.test.ts
@@ -324,8 +324,8 @@ describe('Select social visitors', () => {
 
           // Check inset text is displayed with bullet points for social visitor and not approved
           expect(res.text).toContain('Some visitor details need updating')
-          expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
-          expect(res.text).toContain('is not an approved contact')
+          expect(res.text).toContain('social visitors cannot join official visits')
+          expect(res.text).toContain('a visitor is not an approved contact')
 
           // Check MOJ badges are displayed for SOCIAL VISITOR and CONTACT NOT APPROVED
           expect(res.text).toContain('SOCIAL VISITOR')
@@ -440,7 +440,7 @@ describe('Select social visitors', () => {
 
       const res = await request(app).get(`/manage/amend/1/${journeyId()}/select-social-visitors?change=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('a visitor is not an approved contact')
       expect(res.text).toContain(
         "You can update visitor details in the prisoner's contact record or remove visitors from this visit.",
       )
@@ -484,7 +484,7 @@ describe('Select social visitors', () => {
 
       const res = await request(app).get(`/manage/amend/1/${journeyId()}/select-social-visitors?change=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('a visitor is not an approved contact')
       expect(res.text).toContain('You can remove visitors from this visit.')
       expect(res.text).toContain(
         "You'll need the Contacts Authoriser role to update visitor details in the prisoner's contact record.",

--- a/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.test.ts
@@ -19,6 +19,7 @@ import { mockSocialVisitors, mockPrisonerRestrictions, mockPrisoner } from '../.
 import { expectNoErrorMessages, expectAlertErrors } from '../../../../testutils/expectErrorMessage'
 import { convertToTitleCase, formatDate } from '../../../../../utils/utils'
 import config from '../../../../../config'
+import { AuthorisedRoles } from '../../../../../middleware/populateUserPermissions'
 
 jest.mock('../../../../../services/auditService')
 jest.mock('../../../../../services/prisonerService')
@@ -51,10 +52,11 @@ const appSetup = (
       visitType: 'IN_PERSON',
     } as OfficialVisitJourney,
   },
+  userRoles: AuthorisedRoles[] = user.userRoles as AuthorisedRoles[],
 ) => {
   app = appWithAllRoutes({
     services: { auditService, prisonerService, officialVisitsService },
-    userSupplier: () => user,
+    userSupplier: () => ({ ...user, userRoles }),
     journeySessionSupplier: () => journeySession as Journey,
   })
 }
@@ -398,6 +400,95 @@ describe('Select social visitors', () => {
             correlationId: expect.any(String),
           })
         })
+    })
+
+    it('should show correct inset text when user has both authoriser and manage roles', async () => {
+      const notApprovedVisitor = {
+        ...mockSocialVisitors[2],
+        prisonerContactId: 304,
+        contactId: 304,
+        relationshipToPrisonerCode: 'BRO',
+        relationshipToPrisonerDescription: 'Brother',
+        isApprovedVisitor: false,
+      }
+
+      appSetup(
+        {
+          officialVisit: {
+            prisoner: {
+              ...mockPrisoner,
+              restrictions: mockPrisonerRestrictions,
+            },
+            availableSlots: [{ timeSlotId: 1, visitSlotId: 1 }],
+            selectedTimeSlot: {
+              timeSlotId: 1,
+              visitSlotId: 1,
+              visitDate: '2037-01-26',
+              startTime: '13:30',
+              endTime: '16:00',
+              availableVideoSessions: 2,
+              availableAdults: 3,
+              availableGroups: 2,
+            },
+            socialVisitors: [notApprovedVisitor],
+          } as OfficialVisitJourney,
+        },
+        [AuthorisedRoles.VIEW, AuthorisedRoles.CONTACTS_AUTHORISER, AuthorisedRoles.MANAGE],
+      )
+
+      officialVisitsService.getAllSocialContacts.mockResolvedValue([...mockSocialVisitors, notApprovedVisitor])
+
+      const res = await request(app).get(`/manage/amend/1/${journeyId()}/select-social-visitors?change=true`)
+      expect(res.text).toContain('Some visitor details need updating')
+      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain(
+        "You can update visitor details in the prisoner's contact record or remove visitors from this visit.",
+      )
+    })
+
+    it('should show correct inset text when user has only manage role', async () => {
+      const notApprovedVisitor = {
+        ...mockSocialVisitors[2],
+        prisonerContactId: 304,
+        contactId: 304,
+        relationshipToPrisonerCode: 'BRO',
+        relationshipToPrisonerDescription: 'Brother',
+        isApprovedVisitor: false,
+      }
+
+      appSetup(
+        {
+          officialVisit: {
+            prisoner: {
+              ...mockPrisoner,
+              restrictions: mockPrisonerRestrictions,
+            },
+            availableSlots: [{ timeSlotId: 1, visitSlotId: 1 }],
+            selectedTimeSlot: {
+              timeSlotId: 1,
+              visitSlotId: 1,
+              visitDate: '2037-01-26',
+              startTime: '13:30',
+              endTime: '16:00',
+              availableVideoSessions: 2,
+              availableAdults: 3,
+              availableGroups: 2,
+            },
+            socialVisitors: [notApprovedVisitor],
+          } as OfficialVisitJourney,
+        },
+        [AuthorisedRoles.VIEW, AuthorisedRoles.MANAGE],
+      )
+
+      officialVisitsService.getAllSocialContacts.mockResolvedValue([...mockSocialVisitors, notApprovedVisitor])
+
+      const res = await request(app).get(`/manage/amend/1/${journeyId()}/select-social-visitors?change=true`)
+      expect(res.text).toContain('Some visitor details need updating')
+      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('You can remove visitors from this visit.')
+      expect(res.text).toContain(
+        "You'll need the Contacts Authoriser role to update visitor details in the prisoner's contact record.",
+      )
     })
   })
 

--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
@@ -452,7 +452,7 @@ describe('View an official visit', () => {
 
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('does not have a recorded relationship with the prisoner')
+      expect(res.text).toContain('a visitor does not have a recorded relationship with the prisoner')
       expect(res.text).toContain('govuk-inset-text')
     })
 
@@ -462,7 +462,7 @@ describe('View an official visit', () => {
 
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('a visitor is not an approved contact')
     })
 
     it('should show inset text when visitor is a social visitor for prison without social visits enabled', async () => {
@@ -474,7 +474,7 @@ describe('View an official visit', () => {
 
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain('social visitors cannot join official visits')
     })
 
     it('should show all issue types in inset text when multiple visitor issues exist', async () => {
@@ -486,8 +486,8 @@ describe('View an official visit', () => {
 
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
-      expect(res.text).toContain('is not an approved contact')
+      expect(res.text).toContain('social visitors cannot join official visits')
+      expect(res.text).toContain('a visitor is not an approved contact')
     })
 
     it('should show MOJ badge "NO RECORDED RELATIONSHIP" on visitor card when contact not found', async () => {
@@ -566,7 +566,7 @@ describe('View an official visit', () => {
 
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain('social visitors cannot join official visits')
       expect(res.text).toContain(
         "You can update visitor details in the prisoner's contact record or remove visitors from this visit.",
       )
@@ -583,7 +583,7 @@ describe('View an official visit', () => {
 
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain('social visitors cannot join official visits')
       expect(res.text).toContain("You can update visitor details in the prisoner's contact record.")
       expect(res.text).toContain("You'll need the Official Visits - Manage role to remove visitors from this visit.")
     })
@@ -599,7 +599,7 @@ describe('View an official visit', () => {
 
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain('social visitors cannot join official visits')
       expect(res.text).toContain('You can remove visitors from this visit.')
       expect(res.text).toContain(
         "You'll need the Contacts Authoriser role to update visitor details in the prisoner's contact record.",
@@ -617,7 +617,7 @@ describe('View an official visit', () => {
 
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('Some visitor details need updating')
-      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain('social visitors cannot join official visits')
       expect(res.text).toContain("You'll need:")
       expect(res.text).toContain(
         "the Contacts Authoriser role to update visitor details in the prisoner's contact record",

--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
@@ -11,6 +11,7 @@ import PersonalRelationshipsService from '../../../../services/personalRelations
 import { Prisoner } from '../../../../@types/prisonerSearchApi/types'
 import { convertToTitleCase } from '../../../../utils/utils'
 import ManageUserService from '../../../../services/manageUsersService'
+import { AuthorisedRoles } from '../../../../middleware/populateUserPermissions'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/prisonerService')
@@ -26,7 +27,9 @@ const manageUsersService = new ManageUserService(null) as jest.Mocked<ManageUser
 
 let app: Express
 
-const appSetup = () => {
+const appSetup = (
+  userRoles: AuthorisedRoles[] = [AuthorisedRoles.MANAGE, AuthorisedRoles.CONTACTS_AUTHORISER, AuthorisedRoles.ADMIN],
+) => {
   app = appWithAllRoutes({
     services: {
       auditService,
@@ -35,7 +38,7 @@ const appSetup = () => {
       personalRelationshipsService,
       manageUsersService,
     },
-    userSupplier: () => user,
+    userSupplier: () => ({ ...user, userRoles }),
   })
 }
 
@@ -550,6 +553,76 @@ describe('View an official visit', () => {
       const res = await request(app).get(`${URL}?continue=true`)
       expect(res.text).toContain('/contacts/list')
       expect(res.text).not.toContain('/relationship/7332364')
+    })
+
+    it('should show correct inset text when user has both authoriser and manage roles', async () => {
+      officialVisitsService.getOfficialVisitById.mockResolvedValue({
+        ...baseFutureVisit,
+        officialVisitors: [baseSocialVisitor],
+      })
+      officialVisitsService.getAllContacts.mockResolvedValue([{ ...baseSocialContact, isApprovedVisitor: false }])
+
+      appSetup([AuthorisedRoles.VIEW, AuthorisedRoles.CONTACTS_AUTHORISER, AuthorisedRoles.MANAGE])
+
+      const res = await request(app).get(`${URL}?continue=true`)
+      expect(res.text).toContain('Some visitor details need updating')
+      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain(
+        "You can update visitor details in the prisoner's contact record or remove visitors from this visit.",
+      )
+    })
+
+    it('should show correct inset text when user has only authoriser role', async () => {
+      officialVisitsService.getOfficialVisitById.mockResolvedValue({
+        ...baseFutureVisit,
+        officialVisitors: [baseSocialVisitor],
+      })
+      officialVisitsService.getAllContacts.mockResolvedValue([{ ...baseSocialContact, isApprovedVisitor: false }])
+
+      appSetup([AuthorisedRoles.VIEW, AuthorisedRoles.CONTACTS_AUTHORISER])
+
+      const res = await request(app).get(`${URL}?continue=true`)
+      expect(res.text).toContain('Some visitor details need updating')
+      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain("You can update visitor details in the prisoner's contact record.")
+      expect(res.text).toContain("You'll need the Official Visits - Manage role to remove visitors from this visit.")
+    })
+
+    it('should show correct inset text when user has only manage role', async () => {
+      officialVisitsService.getOfficialVisitById.mockResolvedValue({
+        ...baseFutureVisit,
+        officialVisitors: [baseSocialVisitor],
+      })
+      officialVisitsService.getAllContacts.mockResolvedValue([{ ...baseSocialContact, isApprovedVisitor: false }])
+
+      appSetup([AuthorisedRoles.VIEW, AuthorisedRoles.MANAGE])
+
+      const res = await request(app).get(`${URL}?continue=true`)
+      expect(res.text).toContain('Some visitor details need updating')
+      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain('You can remove visitors from this visit.')
+      expect(res.text).toContain(
+        "You'll need the Contacts Authoriser role to update visitor details in the prisoner's contact record.",
+      )
+    })
+
+    it('should show correct inset text when user has neither authoriser nor manage role', async () => {
+      officialVisitsService.getOfficialVisitById.mockResolvedValue({
+        ...baseFutureVisit,
+        officialVisitors: [baseSocialVisitor],
+      })
+      officialVisitsService.getAllContacts.mockResolvedValue([{ ...baseSocialContact, isApprovedVisitor: false }])
+
+      appSetup([AuthorisedRoles.VIEW])
+
+      const res = await request(app).get(`${URL}?continue=true`)
+      expect(res.text).toContain('Some visitor details need updating')
+      expect(res.text).toContain('is a social visitor for a prison where this is not enabled')
+      expect(res.text).toContain("You'll need:")
+      expect(res.text).toContain(
+        "the Contacts Authoriser role to update visitor details in the prisoner's contact record",
+      )
+      expect(res.text).toContain('the Official Visits - Manage role to remove visitors from this visit')
     })
   })
 })

--- a/server/views/pages/manage/selectOfficialVisitors.njk
+++ b/server/views/pages/manage/selectOfficialVisitors.njk
@@ -20,7 +20,7 @@
   {{ capacityCheckMessages(checks, visitId, prisoner.prisonerNumber) }}
   {{ createJourneyHeader(prisoner, stepsChecked, mode)}}
 
-  {{ unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors) }}
+  {{ unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors, PERMISSION) }}
 
   <div class="govuk-grid-row govuk-body">
     <div class="govuk-grid-column-three-quarters">
@@ -47,15 +47,11 @@
         ]), rows) %}
       {% endfor %}
 
-      {% set captionText %}
-        {{ (prisoner.firstName + ' ' + prisoner.lastName) | convertToTitleCase | possessiveComma }} active restrictions
-      {% endset %}
-
       <div class="govuk-summary-card">
         {% if rows.length > 0 %}
           <div class="govuk-summary-card__content" data-qa="prisoner-restrictions-table">
             {{ govukTable({
-              caption: captionText,
+              caption: (prisoner.firstName + ' ' + prisoner.lastName) | convertToTitleCase | possessiveComma + " active restrictions",
               captionClasses: "govuk-table__caption--m",
               firstCellIsHeader: true,
               head: [
@@ -68,7 +64,7 @@
             }) }}
           </div>
         {% else %}
-          <div class="govuk-summary-card__content govuk-summary-card__title" data-qa="empty-restrictions-title">{{ captionText }}</div>
+          <div class="govuk-summary-card__content govuk-summary-card__title" data-qa="empty-restrictions-title">{{ (prisoner.firstName + ' ' + prisoner.lastName) | convertToTitleCase | possessiveComma }} active restrictions</div>
           <div class="govuk-body govuk-!-margin-top-0 govuk-!-margin-left-4" data-qa="empty-restrictions-message">No active restrictions</div>
         {% endif %}
       </div>

--- a/server/views/pages/manage/selectSocialVisitors.njk
+++ b/server/views/pages/manage/selectSocialVisitors.njk
@@ -20,7 +20,7 @@
   {{ capacityCheckMessages(checks, visitId)}}
   {{ createJourneyHeader(prisoner, stepsChecked, mode)}}
 
-  {{ unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors) }}
+  {{ unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors, PERMISSION) }}
 
   <div class="govuk-grid-row govuk-body">
     <div class="govuk-grid-column-three-quarters">
@@ -48,15 +48,11 @@
 
       {% endfor %}
 
-      {% set captionText %}
-        {{ (prisoner.firstName + ' ' + prisoner.lastName) | convertToTitleCase | possessiveComma }} active restrictions
-      {% endset %}
-
-      <div class="govuk-summary-card">
+        <div class="govuk-summary-card">
         {% if rows.length > 0 %}
           <div class="govuk-summary-card__content" data-qa="prisoner-restrictions-table">
             {{ govukTable({
-              caption: captionText,
+              caption: (prisoner.firstName + ' ' + prisoner.lastName) | convertToTitleCase | possessiveComma + " active restrictions",
               captionClasses: "govuk-table__caption--m",
               firstCellIsHeader: true,
               head: [
@@ -69,7 +65,7 @@
             }) }}
           </div>
         {% else %}
-          <div class="govuk-summary-card__content govuk-summary-card__title">{{ captionText }}</div>
+          <div class="govuk-summary-card__content govuk-summary-card__title">{{ (prisoner.firstName + ' ' + prisoner.lastName) | convertToTitleCase | possessiveComma }} active restrictions</div>
           <div class="govuk-body govuk-!-margin-top-0 govuk-!-margin-left-4">No active restrictions</div>
         {% endif %}
       </div>

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -20,7 +20,7 @@
   <h1 class="govuk-heading-l">Official visit</h1>
   {{ miniProfile(prisoner) }}
 
-  {{ unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors) }}
+  {{ unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors, PERMISSION) }}
 
   {% if mode != 'amend' %}
       {{ govukButton({

--- a/server/views/partials/unauthorisedVisitorsInset.njk
+++ b/server/views/partials/unauthorisedVisitorsInset.njk
@@ -1,10 +1,10 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-{% macro unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors) %}
+{% macro unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors, PERMISSION) %}
   {% if hasIssueVisitors and shouldShowIssues %}
     {% call govukInsetText({ classes: "govuk-!-margin-0 govuk-!-margin-bottom-4 guidance-panel" }) %}
       <h2 class="govuk-heading-s govuk-!-margin-0">Some visitor details need updating</h2>
-      <p>This visit includes one or more visitors who do not currently meeting the requirements for this prison. <br />This is because a visitor:</p>
+      <p>This visit includes one or more people who are not allowed to visit. <br />This is because:</p>
       <ul class="govuk-list govuk-list--bullet">
         {% if hasSocialVisitors %}
           <li>is a social visitor for a prison where this is not enabled</li>
@@ -17,10 +17,20 @@
         {% endif %}
       </ul>
 
-      {% if user | hasPermission(PERMISSION.CONTACTS_AUTHORISER) %}
-        <p>You can update visitor details in the prisoner’s contact record, or remove visitors from this visit if needed.</p>
+      {% if (user | hasPermission(PERMISSION.CONTACTS_AUTHORISER)) and (user | hasPermission(PERMISSION.MANAGE)) %}
+        <p>You can update visitor details in the prisoner's contact record or remove visitors from this visit.</p>
+      {% elif user | hasPermission(PERMISSION.CONTACTS_AUTHORISER) %}
+        <p>You can update visitor details in the prisoner's contact record.</p>
+        <p>You'll need the Official Visits - Manage role to remove visitors from this visit.</p>
+      {% elif user | hasPermission(PERMISSION.MANAGE) %}
+        <p>You can remove visitors from this visit.</p>
+        <p>You'll need the Contacts Authoriser role to update visitor details in the prisoner's contact record.</p>
       {% else %}
-        <p>You will need the contacts authoriser to add a contact in the prisoner’s profile or remove visitors from this visit if needed.</p>
+        <p>You'll need:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the Contacts Authoriser role to update visitor details in the prisoner's contact record</li>
+          <li>the Official Visits - Manage role to remove visitors from this visit</li>
+        </ul>
       {% endif %}
 
       <a target="_blank" href="{{ CONTACTS_HOME_PAGE_URL }}/prisoner/{{ prisoner.prisonerNumber }}/contacts/list" class="govuk-link govuk-link--no-visited-state">View the prisoner’s contact record</a>

--- a/server/views/partials/unauthorisedVisitorsInset.njk
+++ b/server/views/partials/unauthorisedVisitorsInset.njk
@@ -4,16 +4,16 @@
   {% if hasIssueVisitors and shouldShowIssues %}
     {% call govukInsetText({ classes: "govuk-!-margin-0 govuk-!-margin-bottom-4 guidance-panel" }) %}
       <h2 class="govuk-heading-s govuk-!-margin-0">Some visitor details need updating</h2>
-      <p>This visit includes one or more people who are not allowed to visit. <br />This is because:</p>
+      <p>This visit includes one or more people who are not allowed to visit.<br /><br />This is because:</p>
       <ul class="govuk-list govuk-list--bullet">
         {% if hasSocialVisitors %}
-          <li>is a social visitor for a prison where this is not enabled</li>
+          <li>social visitors cannot join official visits</li>
         {% endif %}
         {% if hasNotApprovedVisitors %}
-          <li>is not an approved contact</li>
+          <li>a visitor is not an approved contact</li>
         {% endif %}
         {% if hasNoRelationshipVisitors %}
-          <li>does not have a recorded relationship with the prisoner</li>
+          <li>a visitor does not have a recorded relationship with the prisoner</li>
         {% endif %}
       </ul>
 


### PR DESCRIPTION
Both MANAGE and CONTACTS_AUTHORISER

<img width="848" height="310" alt="image" src="https://github.com/user-attachments/assets/740609d0-9d11-4943-9198-f60431c8ccf4" />

MANAGE only
<img width="910" height="400" alt="image" src="https://github.com/user-attachments/assets/a269c956-4c5e-48b9-9248-af7ad047512c" />

CONTACTS_AUTHORISER (and VIEW) only

<img width="912" height="533" alt="image" src="https://github.com/user-attachments/assets/21fee867-6304-4f34-b484-cc28a7bbb85b" />

VIEW only
<img width="926" height="599" alt="image" src="https://github.com/user-attachments/assets/01ad7db7-20b2-4d88-9559-1863ff1079ef" />

Fix HTML encoding
<img width="899" height="553" alt="image" src="https://github.com/user-attachments/assets/6ed416fd-830b-442f-b681-10ca4b0bce94" />
