### PR TITLE
OV-575 : Add visit change status API and update related handlers and tests

### DIFF
--- a/integration_tests/mockApis/officialVisitsApi.ts
+++ b/integration_tests/mockApis/officialVisitsApi.ts
@@ -152,6 +152,8 @@ export default {
       overlappingContactVisits: number[]
     }>
   }) => simplePostApiMock(`/official-visits-api/official-visit/prison/.*/overlapping`, response),
+  stubGetVisitChangeStatus: (response: { hasChanged: boolean } = { hasChanged: false }) =>
+    simpleApiMock(`/official-visits-api/notification/\\d+/change-status`, response),
   stubSendNotification: (officialVisitId: number, response: RecursivePartial<NotificationResponse> = {}) =>
     simplePostApiMock(`/official-visits-api/notification/${officialVisitId}`, response),
 }

--- a/integration_tests/specs/amendVisit.spec.ts
+++ b/integration_tests/specs/amendVisit.spec.ts
@@ -139,6 +139,7 @@ test.describe('Amend official visits', () => {
       }),
     )
 
+    await officialVisitsApi.stubGetVisitChangeStatus({ hasChanged: false })
     await officialVisitsApi.stubGetOfficialVisitById(getMockVisit() as OfficialVisit)
     await officialVisitsApi.stubAllContacts([...mockOfficialVisitors, ...mockSocialVisitors])
 

--- a/integration_tests/specs/cancelVisits.spec.ts
+++ b/integration_tests/specs/cancelVisits.spec.ts
@@ -60,6 +60,7 @@ test.describe('Cancel an official visit', () => {
     )
 
     await setupFindByCriteriaStubs()
+    await officialVisitsApi.stubGetVisitChangeStatus({ hasChanged: false })
     await officialVisitsApi.stubGetOfficialVisitById(mockVisitByIdVisit)
     await officialVisitsApi.stubCompleteVisit({})
     await officialVisitsApi.stubCancelVisit({})

--- a/integration_tests/specs/completeVisit.spec.ts
+++ b/integration_tests/specs/completeVisit.spec.ts
@@ -69,6 +69,7 @@ test.describe('Complete official visits', () => {
     )
 
     await setupFindByCriteriaStubs()
+    await officialVisitsApi.stubGetVisitChangeStatus({ hasChanged: false })
     await officialVisitsApi.stubGetOfficialVisitById(mockVisitByIdVisit)
     await officialVisitsApi.stubCompleteVisit({})
     await officialVisitsApi.stubCancelVisit({})

--- a/integration_tests/specs/viewVisits.spec.ts
+++ b/integration_tests/specs/viewVisits.spec.ts
@@ -133,6 +133,7 @@ test.describe('View official visits', () => {
     )
 
     await setupFindByCriteriaStubs()
+    await officialVisitsApi.stubGetVisitChangeStatus({ hasChanged: false })
     await officialVisitsApi.stubGetOfficialVisitById(mockVisitByIdVisit)
     await officialVisitsApi.stubCompleteVisit({})
     await officialVisitsApi.stubCancelVisit({})

--- a/server/@types/officialVisitsApi/index.d.ts
+++ b/server/@types/officialVisitsApi/index.d.ts
@@ -131,62 +131,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/queue-admin/retry-dlq/{dlqName}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    /**
-     * @description Requires one of the following roles:
-     *     * OFFICIAL_VISITS_ADMIN
-     */
-    put: operations['retryDlq']
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/queue-admin/retry-all-dlqs': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put: operations['retryAllDlqs']
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/queue-admin/purge-queue/{queueName}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    /**
-     * @description Requires one of the following roles:
-     *     * OFFICIAL_VISITS_ADMIN
-     */
-    put: operations['purgeQueue']
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/official-visit/prison/{prisonCode}/id/{officialVisitId}/visitors': {
     parameters: {
       query?: never
@@ -898,26 +842,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/queue-admin/get-dlq-messages/{dlqName}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * @description Requires one of the following roles:
-     *     * OFFICIAL_VISITS_ADMIN
-     */
-    get: operations['getDlqMessages']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/prisoner/{prisonerNumber}/approved-relationships': {
     parameters: {
       query?: never
@@ -1007,6 +931,29 @@ export interface paths {
      *     * ROLE_OFFICIAL_VISITS_RW
      */
     get: operations['getOfficialVisitById_2']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/notification/{officialVisitId}/change-status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Check if an official visit has been modified since the last notification was sent.
+     * @description Requires one of the following roles:
+     *     * ROLE_OFFICIAL_VISITS_ADMIN
+     *     * ROLE_OFFICIAL_VISITS__R
+     *     * ROLE_OFFICIAL_VISITS_RW
+     */
+    get: operations['getVisitChangeStatus']
     put?: never
     post?: never
     delete?: never
@@ -1744,14 +1691,6 @@ export interface components {
        * @example X999X
        */
       updateUsername: string
-    }
-    RetryDlqResult: {
-      /** Format: int32 */
-      messagesFoundCount: number
-    }
-    PurgeQueueResult: {
-      /** Format: int32 */
-      messagesFoundCount: number
     }
     /** @description The request body for updating  visitors details for an official visit */
     OfficialVisitUpdateVisitorsRequest: {
@@ -3339,19 +3278,6 @@ export interface components {
        */
       officialVisitId: number
     }
-    DlqMessage: {
-      body: {
-        [key: string]: unknown
-      }
-      messageId: string
-    }
-    GetDlqResult: {
-      /** Format: int32 */
-      messagesFoundCount: number
-      /** Format: int32 */
-      messagesReturnedCount: number
-      messages: components['schemas']['DlqMessage'][]
-    }
     ApprovedContact: {
       /**
        * Format: int64
@@ -3705,6 +3631,13 @@ export interface components {
       phoneNumber?: string | null
       /** @description The visitors email address if present */
       emailAddress?: string | null
+    }
+    VisitChangeStatusResponse: {
+      /**
+       * @description Whether the visit details have changed since the last notification was sent
+       * @example true
+       */
+      hasChanged: boolean
     }
     AvailableSlot: {
       /**
@@ -4140,70 +4073,6 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  retryDlq: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        dlqName: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['RetryDlqResult']
-        }
-      }
-    }
-  }
-  retryAllDlqs: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['RetryDlqResult'][]
-        }
-      }
-    }
-  }
-  purgeQueue: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        queueName: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['PurgeQueueResult']
         }
       }
     }
@@ -5930,30 +5799,6 @@ export interface operations {
       }
     }
   }
-  getDlqMessages: {
-    parameters: {
-      query?: {
-        maxMessages?: number
-      }
-      header?: never
-      path: {
-        dlqName: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['GetDlqResult']
-        }
-      }
-    }
-  }
   getApprovedContacts: {
     parameters: {
       query?: {
@@ -6152,6 +5997,59 @@ export interface operations {
         }
       }
       /** @description Official visit not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getVisitChangeStatus: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /**
+         * @description The identifier of the official visit to check for changes.
+         * @example 1
+         */
+        officialVisitId: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Check completed - returns whether the visit has changed since the last notification was sent */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['VisitChangeStatusResponse']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No official visit found with the given ID. */
       404: {
         headers: {
           [name: string]: unknown

--- a/server/data/officialVisitsApiClient.ts
+++ b/server/data/officialVisitsApiClient.ts
@@ -330,6 +330,16 @@ export default class OfficialVisitsApiClient extends RestClient {
     )
   }
 
+  async getVisitChangeStatus(
+    officialVisitId: number,
+    user: HmppsUser,
+  ): Promise<components['schemas']['VisitChangeStatusResponse']> {
+    return this.get<components['schemas']['VisitChangeStatusResponse']>(
+      { path: `/notification/${officialVisitId}/change-status` },
+      asSystem(user.username),
+    )
+  }
+
   async sendNotification(officialVisitId: number, body: NotificationRequest, user: HmppsUser) {
     return this.post<NotificationResponse>(
       { path: `/notification/${officialVisitId}`, data: body },

--- a/server/routes/journeys/manage/visit/handlers/amendVisitLandingHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/amendVisitLandingHandler.test.ts
@@ -48,6 +48,7 @@ beforeEach(() => {
   manageUsersService.getUserByUsername.mockResolvedValue(mockUser)
   prisonerService.getPrisonerByPrisonerNumber.mockResolvedValue(mockPrisoner as unknown as Prisoner)
   officialVisitsService.getAllContacts.mockResolvedValue([])
+  officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: false })
 })
 
 afterEach(() => {
@@ -193,8 +194,9 @@ describe('Search for an official visit', () => {
         })
     })
 
-    it('should not render send email alert or button in amend mode when email notifications are enabled', async () => {
+    it('should not render send email alert or button when hasChanged is false even when email notifications are enabled', async () => {
       config.featureToggles.emailNotificationsEnabled = true
+      officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: false })
       appSetup()
 
       const res = await request(app).get(URL)

--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
@@ -192,7 +192,7 @@ describe('View an official visit', () => {
       const res = await request(app).get(URL)
       const $ = cheerio.load(res.text)
 
-      expect($('#send-email-button').attr('href')).toEqual('/notification/enter-email-address/1/schedule')
+      expect($('#send-email-button').attr('href')).toEqual('/notification/enter-email-address/1/edit')
       expect(res.text).not.toContain(
         'Information about this visit has changed since a confirmation email was last sent',
       )

--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
@@ -198,6 +198,28 @@ describe('View an official visit', () => {
       )
     })
 
+    it('should not render send email alert when email notifications are enabled, hasChanged is true but visit is completed', async () => {
+      config.featureToggles.emailNotificationsEnabled = true
+      officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: true })
+      officialVisitsService.getOfficialVisitById.mockResolvedValue({
+        ...mockVisitByIdVisit,
+        visitStatus: 'COMPLETED',
+        visitStatusDescription: 'Completed',
+        completionNotes: 'Visit completed',
+        completionDescription: 'Normal completion',
+        searchTypeDescription: 'Full search',
+      })
+      appSetup()
+
+      const res = await request(app).get(URL)
+      const $ = cheerio.load(res.text)
+
+      expect($('#send-email-button').length).toBe(0)
+      expect(res.text).not.toContain(
+        'Information about this visit has changed since a confirmation email was last sent',
+      )
+    })
+
     it('should handle null visit.updatedBy', () => {
       officialVisitsService.getOfficialVisitById.mockResolvedValue({ ...mockVisitByIdVisit, updatedBy: null })
       return request(app)

--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
@@ -51,6 +51,7 @@ beforeEach(() => {
   prisonerService.getPrisonerByPrisonerNumber.mockResolvedValue(mockPrisoner as unknown as Prisoner)
   manageUsersService.getUserByUsername.mockResolvedValue(mockUser)
   officialVisitsService.getAllContacts.mockResolvedValue([baseMockContact])
+  officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: false })
 })
 
 afterEach(() => {
@@ -170,8 +171,9 @@ describe('View an official visit', () => {
         })
     })
 
-    it('should render send email alert and button with edit URL when email notifications are enabled', async () => {
+    it('should render send email alert and button with edit URL when email notifications are enabled and hasChanged is true', async () => {
       config.featureToggles.emailNotificationsEnabled = true
+      officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: true })
       appSetup()
 
       const res = await request(app).get(URL)
@@ -180,6 +182,20 @@ describe('View an official visit', () => {
       expect($('#send-email-button').attr('href')).toEqual('/notification/enter-email-address/1/edit')
       expect(res.text).toContain('Information about this visit has changed since a confirmation email was last sent')
       expect($('.moj-alert a.govuk-link').attr('href')).toEqual('/notification/enter-email-address/1/edit')
+    })
+
+    it('should not render send email alert when email notifications are enabled but hasChanged is false', async () => {
+      config.featureToggles.emailNotificationsEnabled = true
+      officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: false })
+      appSetup()
+
+      const res = await request(app).get(URL)
+      const $ = cheerio.load(res.text)
+
+      expect($('#send-email-button').attr('href')).toEqual('/notification/enter-email-address/1/schedule')
+      expect(res.text).not.toContain(
+        'Information about this visit has changed since a confirmation email was last sent',
+      )
     })
 
     it('should handle null visit.updatedBy', () => {
@@ -332,6 +348,7 @@ describe('View an official visit', () => {
 
     it('should render send email alert and button with cancel URL for cancelled visits', async () => {
       config.featureToggles.emailNotificationsEnabled = true
+      officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: true })
       appSetup()
       officialVisitsService.getOfficialVisitById.mockResolvedValue({
         ...mockVisitByIdVisit,

--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.ts
@@ -36,7 +36,7 @@ export default class ViewOfficialVisitHandler implements PageHandler {
     const prisonCode = req.session.activeCaseLoadId
     const visit = await this.officialVisitsService.getOfficialVisitById(Number(ovId), user)
 
-    const [restrictions, prisoner, contacts] = await Promise.all([
+    const [restrictions, prisoner, contacts, visitChangeStatus] = await Promise.all([
       this.personalRelationshipsService.getPrisonerRestrictions(
         visit.prisonerVisited.prisonerNumber,
         0,
@@ -47,6 +47,7 @@ export default class ViewOfficialVisitHandler implements PageHandler {
       ),
       this.prisonerService.getPrisonerByPrisonerNumber(visit.prisonerVisited.prisonerNumber, user),
       this.officialVisitsService.getAllContacts(visit.prisonerVisited.prisonerNumber, user),
+      this.officialVisitsService.getVisitChangeStatus(Number(ovId), user),
     ])
 
     const enrichedVisitors = await Promise.all(
@@ -138,6 +139,7 @@ export default class ViewOfficialVisitHandler implements PageHandler {
       hasNotApprovedVisitors,
       hasSocialVisitors,
       hasIssueVisitors,
+      hasVisitChanged: visitChangeStatus.hasChanged,
       shouldShowIssues: isFuture(new Date(`${visit.visitDate} ${visit.startTime}`)) && !visit.completionCode,
     })
   }

--- a/server/services/officialVisitsService.ts
+++ b/server/services/officialVisitsService.ts
@@ -187,6 +187,10 @@ export default class OfficialVisitsService {
     return this.officialVisitsApiClient.updateComments(prisonId, visitId, body, user)
   }
 
+  public async getVisitChangeStatus(officialVisitId: number, user: HmppsUser): Promise<{ hasChanged: boolean }> {
+    return this.officialVisitsApiClient.getVisitChangeStatus(officialVisitId, user)
+  }
+
   public async sendNotification(visitId: string, body: NotificationRequest, user: HmppsUser) {
     logger.info(`Send notification for visit id ${visitId} and notification type ${body.notificationType}`)
     return this.officialVisitsApiClient.sendNotification(Number(visitId), body, user)

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -20,7 +20,7 @@
   <h1 class="govuk-heading-l">Official visit</h1>
   {{ miniProfile(prisoner) }}
 
-        {% if EMAIL_NOTIFICATIONS_ENABLED and mode != 'amend' %}
+        {% if EMAIL_NOTIFICATIONS_ENABLED and mode != 'amend' and hasVisitChanged %}
             {% set notificationPath = "/notification/enter-email-address/" + visit.officialVisitId + ("/cancel" if visit.visitStatus == 'CANCELLED' else "/edit") %}
             {{ mojAlert({
               variant: "warning",

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -20,7 +20,7 @@
   <h1 class="govuk-heading-l">Official visit</h1>
   {{ miniProfile(prisoner) }}
 
-        {% if EMAIL_NOTIFICATIONS_ENABLED and mode != 'amend' and hasVisitChanged %}
+        {% if EMAIL_NOTIFICATIONS_ENABLED and mode != 'amend' and hasVisitChanged and visit.visitStatus in ['CANCELLED', 'SCHEDULED'] %}
             {% set notificationPath = "/notification/enter-email-address/" + visit.officialVisitId + ("/cancel" if visit.visitStatus == 'CANCELLED' else "/edit") %}
             {{ mojAlert({
               variant: "warning",


### PR DESCRIPTION
This pull request introduces support for checking whether an official visit has changed since the last notification was sent, and updates the user interface and integration tests accordingly. The main goal is to ensure that email alert banners and buttons are only shown when relevant, based on the visit's change status.

test evidence:

https://github.com/user-attachments/assets/76bf9a8b-affb-437d-8e76-30cd2ee4b8a1



