### PR TITLE
OV-606 : Update links and navigation in visit and email notification pages

### DIFF
--- a/server/routes/journeys/notification/handlers/checkHandler.test.ts
+++ b/server/routes/journeys/notification/handlers/checkHandler.test.ts
@@ -80,6 +80,8 @@ describe('notification check handler', () => {
     // Description text for non-cancel action
     expect(res.text).toContain('A confirmation email will be sent confirming the details of this official visit.')
     expect(res.text).not.toContain('the cancellation of this official visit')
+    expect($('.govuk-link').last().text()).toContain('Cancel and return to homepage')
+    expect($('.govuk-link').last().attr('href')).toContain(`/`)
   })
 
   it('GET should show cancellation text in description for cancel action', async () => {

--- a/server/routes/journeys/notification/handlers/checkHandler.ts
+++ b/server/routes/journeys/notification/handlers/checkHandler.ts
@@ -45,7 +45,7 @@ export default class CheckHandler implements PageHandler {
       emailAddress,
       visit,
       contacts,
-      back: `/notification/enter-email-address/${ovId}/${action}`,
+      back: '/',
       change: `/notification/enter-email-address/${ovId}/${action}`,
       ovId,
       action,

--- a/server/routes/journeys/notification/handlers/sentHandler.test.ts
+++ b/server/routes/journeys/notification/handlers/sentHandler.test.ts
@@ -68,8 +68,10 @@ describe('notification sent handler', () => {
       'You should check to confirm this email has been sent successfully. If you update or cancel this visit, you should send another email.',
     )
     // find the link that points to the view visit URL
-    const viewLink = $(`a.govuk-link[href="/view/visit/${OV_ID}"]`)
-    expect(viewLink.length).toBe(1)
+    expect($('.govuk-link').eq(2).text()).toContain('View visit')
+    expect($('.govuk-link').eq(2).attr('href')).toContain(`/view/visit/${OV_ID}`)
+    expect($('.govuk-link').last().text()).toContain('View the status of official visit emails')
+    expect($('.govuk-link').last().attr('href')).toContain(`/view/sent-emails`)
     // assert session is reset
     expect(capturedSession!.notifications).toEqual({ [OV_ID]: {} })
   })

--- a/server/routes/journeys/view/handlers/sentEmailsHandler.test.ts
+++ b/server/routes/journeys/view/handlers/sentEmailsHandler.test.ts
@@ -117,6 +117,7 @@ describe('sent emails handler', () => {
     expect($('#fromDate').attr('value')).toBeUndefined()
     expect($('#toDate').attr('value')).toBeUndefined()
     expect($('.moj-pagination__results').first().text()).toContain('Showing 1 to 10 of 11 total results')
+    expect(res.text).toContain('<a href="/" class="govuk-back-link">Back</a>')
 
     const headers = $('.govuk-table__header')
     expect(headers.eq(0).text().trim()).toEqual('Visit date and time')

--- a/server/routes/journeys/view/handlers/sentEmailsHandler.ts
+++ b/server/routes/journeys/view/handlers/sentEmailsHandler.ts
@@ -75,6 +75,7 @@ export default class SentEmailsHandler implements PageHandler {
 
     return res.render('pages/view/sentEmails', {
       pageTitle: `Official visit emails sent from ${prisonName}`,
+      backUrl: `/`,
       fromDateValue,
       prisonName,
       toDateValue,

--- a/server/views/pages/notification/sent.njk
+++ b/server/views/pages/notification/sent.njk
@@ -20,7 +20,7 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-6">What you can do next</h2>
       <ul class="govuk-list govuk-!-margin-bottom-6">
         <li><a class="govuk-link govuk-link--no-visited-state" href="/view/visit/{{ ovId }}">View visit</a></li>
-        <li><a class="govuk-link govuk-link--no-visited-state" href="/notification/emails">View the status of official visit emails</a></li>
+        <li><a class="govuk-link govuk-link--no-visited-state" href="/view/sent-emails">View the status of official visit emails</a></li>
       </ul>
     </div>
   </div>

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -25,6 +25,7 @@
             {{ mojAlert({
               variant: "warning",
               title: "Information about this visit has changed since a confirmation email was last sent",
+              showTitleAsHeading: true,
               dismissible: false,
               html: "You should <a href='" + notificationPath + "' class='govuk-link'>send another email</a> to update visitors with new information."
             }) }}


### PR DESCRIPTION
This pull request updates the notification journey's navigation and improves the clarity and accuracy of links and alerts for users. The main changes are to the navigation flow after sending notifications, the display and targets of key action links, and a minor improvement to the visit change alert.

* The visit change warning alert now explicitly displays its title as a heading, improving accessibility and emphasis for users.