### PR TITLE
OV-606-add-action-column

### DIFF
--- a/server/routes/journeys/view/handlers/sentEmailsHandler.test.ts
+++ b/server/routes/journeys/view/handlers/sentEmailsHandler.test.ts
@@ -132,12 +132,13 @@ describe('sent emails handler', () => {
     expect(headers.eq(2).text().trim()).toEqual('Email address')
     expect(headers.eq(3).text().trim()).toEqual('Email status')
     expect(headers.eq(4).text().trim()).toEqual('Email sent')
+    expect(headers.eq(5).text().trim()).toEqual('Action')
 
     expect(getGovukTableCell($, 1, 1).text()).toContain('13:30 to 16:00')
     expect(getGovukTableCell($, 1, 1).text()).toContain('21 May 2026')
     expect(getGovukTableCell($, 1, 2).text()).toContain('Harrison, Tim')
     expect(getGovukTableCell($, 1, 2).text()).toContain('G4793VF')
-    expect(getGovukTableCell($, 1, 2).find('a').attr('href')).toEqual('/view/visit/4006')
+    expect(getGovukTableCell($, 1, 2).find('a').attr('href')).toContain('/prisoner/G4793VF')
     expect(getGovukTableCell($, 1, 3).text()).toEqual('prabash.balasuriya@justice.gov.uk')
     expect(getGovukTableCell($, 1, 4).find('.govuk-tag').text().trim()).toEqual('SENT')
     expect(getGovukTableCell($, 1, 4).find('.govuk-tag').hasClass('govuk-tag--green')).toEqual(true)
@@ -145,6 +146,7 @@ describe('sent emails handler', () => {
     expect(getGovukTableCell($, 2, 4).find('.govuk-tag').hasClass('govuk-tag--red')).toEqual(true)
     expect(getGovukTableCell($, 1, 5).text()).toContain('12:23')
     expect(getGovukTableCell($, 1, 5).text()).toContain('10 May 2026')
+    expect(getGovukTableCell($, 1, 6).find('a').attr('href')).toEqual('/view/visit/4006')
 
     expect(officialVisitsService.getSentEmails).toHaveBeenCalledWith(
       user.activeCaseLoadId,

--- a/server/routes/journeys/view/handlers/sentEmailsHandler.test.ts
+++ b/server/routes/journeys/view/handlers/sentEmailsHandler.test.ts
@@ -147,6 +147,7 @@ describe('sent emails handler', () => {
     expect(getGovukTableCell($, 1, 5).text()).toContain('12:23')
     expect(getGovukTableCell($, 1, 5).text()).toContain('10 May 2026')
     expect(getGovukTableCell($, 1, 6).find('a').attr('href')).toEqual('/view/visit/4006')
+    expect(getGovukTableCell($, 1, 6).text()).toContain('View')
 
     expect(officialVisitsService.getSentEmails).toHaveBeenCalledWith(
       user.activeCaseLoadId,

--- a/server/views/pages/manage/confirmVisit.njk
+++ b/server/views/pages/manage/confirmVisit.njk
@@ -35,8 +35,7 @@
 
       <h2 class='govuk-heading-m'>What you can do next</h2>
 
-      {# TODO: Add links to the correct pages #}
-      <ul class="govuk-list">
+      <ul class="govuk-list govuk-list--spaced">
         <li class="govuk-!-margin-bottom-2">
           <a href="/view/visit/{{ officialVisitId }}" class="govuk-link govuk-link--no-visited-state">View visit</a>
         </li>

--- a/server/views/pages/view/sentEmails.njk
+++ b/server/views/pages/view/sentEmails.njk
@@ -71,7 +71,7 @@
           {% endset %}
 
            {% set actionHtml %}
-              <a class="govuk-link govuk-link--no-visited-state" href="/view/visit/{{ email.officialVisitId }}">Select</a><br>
+              <a class="govuk-link govuk-link--no-visited-state" href="/view/visit/{{ email.officialVisitId }}">View</a><br>
            {% endset %}
 
           {% set rows = (rows.push([

--- a/server/views/pages/view/sentEmails.njk
+++ b/server/views/pages/view/sentEmails.njk
@@ -52,7 +52,7 @@
         {% set rows = [] %}
         {% for email in results.content %}
           {% set prisonerHtml %}
-            <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="/view/visit/{{ email.officialVisitId }}"> {{ (email.lastName + ", " + email.firstName) | convertToTitleCase }}</a><br>{{ email.prisonerNumber }}
+            <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{prisonerProfileUrl}}/prisoner/{{ email.prisonerNumber }}"> {{ (email.lastName + ", " + email.firstName) | convertToTitleCase }}</a><br>{{ email.prisonerNumber }}
           {% endset %}
 
           {% set dateAndTimeHtml %}
@@ -70,12 +70,17 @@
             }) }}
           {% endset %}
 
+           {% set actionHtml %}
+              <a class="govuk-link govuk-link--no-visited-state" href="/view/visit/{{ email.officialVisitId }}">Select</a><br>
+           {% endset %}
+
           {% set rows = (rows.push([
             { html: dateAndTimeHtml },
             { html: prisonerHtml },
             { text: email.emailAddress },
             { html: emailStatusHtml },
-            { html: emailSentHtml }
+            { html: emailSentHtml },
+            { html: actionHtml }
           ]), rows) %}
         {% endfor %}
 
@@ -87,7 +92,8 @@
             { text: 'Prisoner' },
             { text: 'Email address' },
             { text: 'Email status' },
-            { text: 'Email sent' }
+            { text: 'Email sent' },
+            { text: 'Action' }
           ],
           rows: rows
         }) }}


### PR DESCRIPTION
The main changes include adding an "Action" column with a "Select" link for each email row, updating links to prisoner profiles, and improving the visual spacing of the "What you can do next" list.


- add a new column - 'View' and link to the view visit page.

<img width="804" height="184" alt="image" src="https://github.com/user-attachments/assets/97cea9e4-c823-4e1c-ad0f-3cf3f3fac483" />

- fix url for profile link

<img width="467" height="126" alt="image" src="https://github.com/user-attachments/assets/eae64edf-288a-41c4-ba9d-f036d7cbbb95" />

