### PR TITLE
OV-748: Updating API types, and calls to sent-emails endpoints

### DIFF
--- a/server/@types/officialVisitsApi/index.d.ts
+++ b/server/@types/officialVisitsApi/index.d.ts
@@ -390,7 +390,6 @@ export interface paths {
      *
      *     Requires one of the following roles:
      *     * OFFICIAL_VISITS_MIGRATION
-     *     * OFFICIAL_VISITS_ADMIN
      */
     post: operations['repairPrisonerVisits']
     delete?: never
@@ -540,7 +539,7 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * Endpoint to support the sending of notifications for official visits.
+     * Send notifications for an official visit
      * @description Requires one of the following roles:
      *     * ROLE_OFFICIAL_VISITS_ADMIN
      *     * ROLE_OFFICIAL_VISITS__RW
@@ -562,13 +561,13 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * Endpoint to retrieve a list of sent email notifications with search and pagination support.
+     * Retrieve a list of sent notifications with search parameters and pagination support.
      * @description Requires one of the following roles:
      *     * ROLE_OFFICIAL_VISITS_ADMIN
      *     * ROLE_OFFICIAL_VISITS__R
      *     * ROLE_OFFICIAL_VISITS_RW
      */
-    post: operations['searchSentEmails']
+    post: operations['searchSentNotifications']
     delete?: never
     options?: never
     head?: never
@@ -707,20 +706,19 @@ export interface paths {
      * Endpoint to return one official visit by ID
      * @description Requires one of the following roles:
      *     * OFFICIAL_VISITS_MIGRATION
-     *     * OFFICIAL_VISITS_ADMIN
      */
     get: operations['getOfficialVisitById']
     put?: never
     post?: never
     /**
      * Delete an official visit by ID
-     * @description Delete an official visit including all related information.
+     * @description Requires role: OFFICIAL_VISITS_MIGRATION.
+     *           Delete an official visit including all related information.
      *           This endpoint is idempotent, so if the visit is not present it will silently succeed.
      *
      *
      *     Requires one of the following roles:
      *     * OFFICIAL_VISITS_MIGRATION
-     *     * OFFICIAL_VISITS_ADMIN
      */
     delete: operations['syncDeleteOfficialVisit']
     options?: never
@@ -830,9 +828,8 @@ export interface paths {
      * Return all official visits for a prisoner between two dates with optional current term flag
      * @description Requires one of the following roles:
      *     * OFFICIAL_VISITS_MIGRATION
-     *     * OFFICIAL_VISITS_ADMIN
      */
-    get: operations['getAllOfficialVisitForPrisoner']
+    get: operations['getAllOfficialVisitsForPrisoner']
     put?: never
     post?: never
     delete?: never
@@ -852,7 +849,6 @@ export interface paths {
      * Return a paged list of all official visit IDs
      * @description Requires one of the following roles:
      *     * OFFICIAL_VISITS_MIGRATION
-     *     * OFFICIAL_VISITS_ADMIN
      */
     get: operations['getAllOfficialVisitIds']
     put?: never
@@ -874,7 +870,6 @@ export interface paths {
      * Return one official visit by ID
      * @description Requires one of the following roles:
      *     * OFFICIAL_VISITS_MIGRATION
-     *     * OFFICIAL_VISITS_ADMIN
      */
     get: operations['getOfficialVisitById_1']
     put?: never
@@ -982,6 +977,29 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/official-visit/id/{officialVisitId}/notifications': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get all notifications sent for an official visit ID.
+     * @description Requires one of the following roles:
+     *     * ROLE_OFFICIAL_VISITS_ADMIN
+     *     * ROLE_OFFICIAL_VISITS__R
+     *     * ROLE_OFFICIAL_VISITS_RW
+     */
+    get: operations['getNotificationsByOfficialVisitId']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/official-visit/id/{officialVisitId}/audited-events': {
     parameters: {
       query?: never
@@ -1067,7 +1085,7 @@ export interface paths {
      *
      *
      *     Requires one of the following roles:
-     *     * OFFICIAL_VISITS_ADMIN
+     *     * ROLE_OFFICIAL_VISITS_ADMIN
      */
     get: operations['getAllTimeSlotsAndVisitSlots']
     put?: never
@@ -1201,7 +1219,9 @@ export interface paths {
     trace?: never
   }
 }
+
 export type webhooks = Record<string, never>
+
 export interface components {
   schemas: {
     /** @description Request to Update a new prison visit slot for official visits */
@@ -2946,8 +2966,8 @@ export interface components {
       /** @description The recipients the notification was sent to */
       recipients: components['schemas']['NotificationRecipient'][]
     }
-    /** @description The request containing sent-email search criteria */
-    SentEmailSearchCriteria: {
+    /** @description Notification search request */
+    NotificationSearchRequest: {
       /**
        * Format: date
        * @description The start date filter (optional)
@@ -2961,11 +2981,11 @@ export interface components {
        */
       toDate?: string | null
     }
-    PagedModelSentEmailRecord: {
-      content?: components['schemas']['SentEmailRecord'][]
+    PagedModelSentNotification: {
+      content?: components['schemas']['SentNotification'][]
       page?: components['schemas']['PageMetadata']
     }
-    SentEmailRecord: {
+    SentNotification: {
       /**
        * Format: int64
        * @description The official visit ID
@@ -3739,6 +3759,59 @@ export interface components {
       /** @description The visitors email address if present */
       emailAddress?: string | null
     }
+    OfficialVisitNotification: {
+      /**
+       * Format: int64
+       * @description The notification id
+       * @example 1
+       */
+      notificationId: number
+      /**
+       * Format: int64
+       * @description The official visit id
+       * @example 1
+       */
+      officialVisitId: number
+      /**
+       * @description The template id
+       * @example 1
+       */
+      templateId: string
+      /**
+       * @description The email address
+       * @example exmple@example.com
+       */
+      emailAddress: string
+      /**
+       * @description The reason
+       * @example the reason
+       */
+      reason: string
+      /**
+       * Format: uuid
+       * @description The gov notify notification id
+       * @example 12345678-1234-1234-1234-123456789012
+       */
+      govNotifyNotificationId: string
+      /**
+       * @description The email status
+       * @example SENT
+       * @enum {string}
+       */
+      emailStatus: 'PENDING' | 'SENT' | 'PERMANENT_FAILURE' | 'TEMPORARY_FAILURE' | 'TECHNICAL_FAILURE' | 'UNKNOWN'
+      /**
+       * Format: date-time
+       * @description The created time
+       * @example 09:00
+       */
+      createdTime: string
+      /**
+       * Format: date-time
+       * @description The status updated time
+       * @example 10:00
+       */
+      statusUpdatedTime?: string | null
+    }
     AuditedEventChange: {
       /**
        * @description The name of the field affected by the audited event
@@ -3931,7 +4004,9 @@ export interface components {
   headers: never
   pathItems: never
 }
+
 export type $defs = Record<string, never>
+
 export interface operations {
   syncGetVisitSlotById: {
     parameters: {
@@ -5369,10 +5444,10 @@ export interface operations {
       }
     }
   }
-  searchSentEmails: {
+  searchSentNotifications: {
     parameters: {
       query?: {
-        /** @description Zero-based page index (0..N) */
+        /** @description Zero-based page index (0..n) */
         page?: number
         /** @description The size of the page to be returned */
         size?: number
@@ -5389,7 +5464,7 @@ export interface operations {
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['SentEmailSearchCriteria']
+        'application/json': components['schemas']['NotificationSearchRequest']
       }
     }
     responses: {
@@ -5399,7 +5474,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['PagedModelSentEmailRecord']
+          'application/json': components['schemas']['PagedModelSentNotification']
         }
       }
       /** @description Unauthorised, requires a valid Oauth2 token */
@@ -5972,7 +6047,7 @@ export interface operations {
       }
     }
   }
-  getAllOfficialVisitForPrisoner: {
+  getAllOfficialVisitsForPrisoner: {
     parameters: {
       query?: {
         /** @description Current term only, true of false. Defaults to true. */
@@ -6305,6 +6380,53 @@ export interface operations {
       }
       /** @description Official visit not found */
       404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getNotificationsByOfficialVisitId: {
+    parameters: {
+      query?: {
+        /** @description Sort results by created time desc or asc, default to ASC */
+        sortDirection?: 'ASC' | 'DESC'
+      }
+      header?: never
+      path: {
+        /**
+         * @description The official visit identifier
+         * @example 1
+         */
+        officialVisitId: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description A list of notification rows for the official visit */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OfficialVisitNotification'][]
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
         headers: {
           [name: string]: unknown
         }

--- a/server/@types/officialVisitsApi/types.ts
+++ b/server/@types/officialVisitsApi/types.ts
@@ -46,5 +46,5 @@ export type OfficialVisitUpdateCommentRequest = components['schemas']['OfficialV
 export type OverlappingVisitsResponse = components['schemas']['OverlappingVisitsResponse']
 export type NotificationRequest = components['schemas']['NotificationRequest']
 export type NotificationResponse = components['schemas']['NotificationResponse']
-export type SentEmailSearchCriteriaRequest = components['schemas']['SentEmailSearchCriteria']
-export type PagedModelSentEmailRecord = components['schemas']['PagedModelSentEmailRecord']
+export type NotificationSearchRequest = components['schemas']['NotificationSearchRequest']
+export type PagedModelSentNotification = components['schemas']['PagedModelSentNotification']

--- a/server/data/officialVisitsApiClient.ts
+++ b/server/data/officialVisitsApiClient.ts
@@ -22,8 +22,8 @@ import {
   OfficialVisitUpdateVisitorsRequest,
   OverlappingVisitsResponse,
   ReferenceDataItem,
-  SentEmailSearchCriteriaRequest,
-  PagedModelSentEmailRecord,
+  NotificationSearchRequest,
+  PagedModelSentNotification,
   TimeSlot,
   TimeSlotSummary,
   TimeSlotSummaryItem,
@@ -347,18 +347,18 @@ export default class OfficialVisitsApiClient extends RestClient {
     )
   }
 
-  async searchSentEmails(
+  async searchSentNotifications(
     prisonCode: string,
-    criteria: SentEmailSearchCriteriaRequest,
+    request: NotificationSearchRequest,
     page: number,
     size: number,
     user: HmppsUser,
   ) {
-    return this.post<PagedModelSentEmailRecord>(
+    return this.post<PagedModelSentNotification>(
       {
-        path: `/notification/prison/${prisonCode}/sent-emails`,
+        path: `/notification/prison/${prisonCode}/sent-notifications`,
         query: { page, size },
-        data: criteria,
+        data: request,
       },
       asSystem(user.username),
     )

--- a/server/routes/journeys/view/handlers/sentEmailsHandler.test.ts
+++ b/server/routes/journeys/view/handlers/sentEmailsHandler.test.ts
@@ -5,7 +5,7 @@ import { subDays } from 'date-fns'
 import { appWithAllRoutes, flashProvider, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
 import OfficialVisitsService from '../../../../services/officialVisitsService'
-import { PagedModelSentEmailRecord } from '../../../../@types/officialVisitsApi/types'
+import { PagedModelSentNotification } from '../../../../@types/officialVisitsApi/types'
 import { getGovukTableCell, getPageHeader } from '../../../testutils/cheerio'
 import { expectErrorMessages } from '../../../testutils/expectErrorMessage'
 import { formatDate } from '../../../../utils/utils'
@@ -41,7 +41,7 @@ afterEach(() => {
 
 const URL = '/view/sent-emails'
 
-const RESULTS: PagedModelSentEmailRecord = {
+const RESULTS: PagedModelSentNotification = {
   content: [
     {
       officialVisitId: 4006,
@@ -97,7 +97,7 @@ const RESULTS: PagedModelSentEmailRecord = {
   },
 }
 
-const PAGE_2_RESULTS: PagedModelSentEmailRecord = {
+const PAGE_2_RESULTS: PagedModelSentNotification = {
   ...RESULTS,
   content: [RESULTS.content[0], RESULTS.content[1], RESULTS.content[2]],
   page: {
@@ -110,7 +110,7 @@ const PAGE_2_RESULTS: PagedModelSentEmailRecord = {
 
 describe('sent emails handler', () => {
   it('GET should render the sent emails page with every table value and pagination', async () => {
-    officialVisitsService.getSentEmails.mockResolvedValue(RESULTS)
+    officialVisitsService.getSentNotifications.mockResolvedValue(RESULTS)
 
     const res = await request(app).get(URL).expect(200)
     const $ = cheerio.load(res.text)
@@ -149,7 +149,7 @@ describe('sent emails handler', () => {
     expect(getGovukTableCell($, 1, 6).find('a').attr('href')).toEqual('/view/visit/4006')
     expect(getGovukTableCell($, 1, 6).text()).toContain('View')
 
-    expect(officialVisitsService.getSentEmails).toHaveBeenCalledWith(
+    expect(officialVisitsService.getSentNotifications).toHaveBeenCalledWith(
       user.activeCaseLoadId,
       {
         fromDate: formatDate(fromDate, 'yyyy-MM-dd'),
@@ -166,7 +166,7 @@ describe('sent emails handler', () => {
   })
 
   it('GET should preserve date range search values and paginate with query params', async () => {
-    officialVisitsService.getSentEmails.mockResolvedValue(PAGE_2_RESULTS)
+    officialVisitsService.getSentNotifications.mockResolvedValue(PAGE_2_RESULTS)
 
     const res = await request(app).get(`${URL}?page=2&fromDate=15/05/2026&toDate=20/05/2026`).expect(200)
     const $ = cheerio.load(res.text)
@@ -180,7 +180,7 @@ describe('sent emails handler', () => {
       '?fromDate=15%2F05%2F2026&toDate=20%2F05%2F2026&page=3',
     )
 
-    expect(officialVisitsService.getSentEmails).toHaveBeenCalledWith(
+    expect(officialVisitsService.getSentNotifications).toHaveBeenCalledWith(
       user.activeCaseLoadId,
       {
         fromDate: '2026-05-15',

--- a/server/routes/journeys/view/handlers/sentEmailsHandler.ts
+++ b/server/routes/journeys/view/handlers/sentEmailsHandler.ts
@@ -5,11 +5,11 @@ import { PageHandler } from '../../../interfaces/pageHandler'
 import OfficialVisitsService from '../../../../services/officialVisitsService'
 import { formatDate } from '../../../../utils/utils'
 import { schema, SchemaType } from './sentEmailsHandlerSchema'
-import { SentEmailSearchCriteriaRequest, PagedModelSentEmailRecord } from '../../../../@types/officialVisitsApi/types'
+import { NotificationSearchRequest, PagedModelSentNotification } from '../../../../@types/officialVisitsApi/types'
 
 const PAGE_SIZE = 10
 
-const EMPTY_RESULTS: PagedModelSentEmailRecord = {
+const EMPTY_RESULTS: PagedModelSentNotification = {
   content: [],
   page: {
     number: 0,
@@ -56,25 +56,25 @@ export default class SentEmailsHandler implements PageHandler {
     const toDate = search.toDate || new Date()
     const toDateValue = formResponses.toDate || formatInputDate(toDate)
 
-    const criteria: SentEmailSearchCriteriaRequest = {}
+    const request: NotificationSearchRequest = {}
     if (fromDate) {
       const formattedFromDate = formatDate(fromDate, 'yyyy-MM-dd')
-      if (formattedFromDate) criteria.fromDate = formattedFromDate
+      if (formattedFromDate) request.fromDate = formattedFromDate
     }
     if (toDate) {
       const formattedToDate = formatDate(toDate || new Date(), 'yyyy-MM-dd')
-      if (formattedToDate) criteria.toDate = formattedToDate
+      if (formattedToDate) request.toDate = formattedToDate
     }
 
-    const results: PagedModelSentEmailRecord = res.locals.validationErrors
+    const results: PagedModelSentNotification = res.locals.validationErrors
       ? EMPTY_RESULTS
-      : await (this.officialVisitsService.getSentEmails(
+      : await (this.officialVisitsService.getSentNotifications(
           prisonCode,
-          criteria,
+          request,
           page,
           PAGE_SIZE,
           res.locals.user,
-        ) as Promise<PagedModelSentEmailRecord>)
+        ) as Promise<PagedModelSentNotification>)
 
     return res.render('pages/view/sentEmails', {
       pageTitle: `Official visit emails sent from ${prisonName}`,

--- a/server/services/officialVisitsService.test.ts
+++ b/server/services/officialVisitsService.test.ts
@@ -8,7 +8,7 @@ import {
   OfficialVisitUpdateCommentRequest,
   OfficialVisitUpdateSlotRequest,
   OfficialVisitUpdateVisitorsRequest,
-  PagedModelSentEmailRecord,
+  PagedModelSentNotification,
   TimeSlotSummary,
 } from '../@types/officialVisitsApi/types'
 import { mockFindByCriteriaResults } from '../testutils/mocks'
@@ -238,7 +238,7 @@ describe('OfficialVisitsService', () => {
   })
 
   it('should retrieve sent emails via API client endpoint', async () => {
-    const apiResponse: PagedModelSentEmailRecord = {
+    const apiResponse: PagedModelSentNotification = {
       content: [
         {
           officialVisitId: 4006,
@@ -264,9 +264,9 @@ describe('OfficialVisitsService', () => {
       },
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    officialVisitsApiClient.searchSentEmails.mockResolvedValue(apiResponse as any)
+    officialVisitsApiClient.searchSentNotifications.mockResolvedValue(apiResponse as any)
 
-    const result = await officialVisitsService.getSentEmails(
+    const result = await officialVisitsService.getSentNotifications(
       'MDI',
       {
         fromDate: '2026-05-18',
@@ -277,8 +277,8 @@ describe('OfficialVisitsService', () => {
       user,
     )
 
-    expect(officialVisitsApiClient.searchSentEmails).toHaveBeenCalledTimes(1)
-    expect(officialVisitsApiClient.searchSentEmails).toHaveBeenCalledWith(
+    expect(officialVisitsApiClient.searchSentNotifications).toHaveBeenCalledTimes(1)
+    expect(officialVisitsApiClient.searchSentNotifications).toHaveBeenCalledWith(
       'MDI',
       {
         fromDate: '2026-05-18',
@@ -296,7 +296,7 @@ describe('OfficialVisitsService', () => {
   })
 
   it('should throw if prison code is missing when retrieving sent emails', async () => {
-    await expect(officialVisitsService.getSentEmails('', {}, 1, 10, user)).rejects.toThrow(
+    await expect(officialVisitsService.getSentNotifications('', {}, 1, 10, user)).rejects.toThrow(
       'Cannot retrieve sent emails without a prison code',
     )
   })

--- a/server/services/officialVisitsService.ts
+++ b/server/services/officialVisitsService.ts
@@ -20,8 +20,8 @@ import {
   CreateVisitSlotRequest,
   OverlappingVisitsResponse,
   NotificationRequest,
-  SentEmailSearchCriteriaRequest,
-  PagedModelSentEmailRecord,
+  NotificationSearchRequest,
+  PagedModelSentNotification,
 } from '../@types/officialVisitsApi/types'
 import { OfficialVisitJourney } from '../routes/journeys/manage/visit/journey'
 import logger from '../../logger'
@@ -196,19 +196,19 @@ export default class OfficialVisitsService {
     return this.officialVisitsApiClient.sendNotification(Number(visitId), body, user)
   }
 
-  public async getSentEmails(
+  public async getSentNotifications(
     prisonId: string,
-    criteria: SentEmailSearchCriteriaRequest,
+    request: NotificationSearchRequest,
     page: number,
     size: number,
     user: HmppsUser,
-  ): Promise<PagedModelSentEmailRecord> {
+  ): Promise<PagedModelSentNotification> {
     if (!prisonId?.trim()) {
       throw new Error('Cannot retrieve sent emails without a prison code')
     }
 
-    logger.info(`Get sent emails called by ${user.userId} with criteria ${JSON.stringify(criteria)}`)
-    return this.officialVisitsApiClient.searchSentEmails(prisonId, criteria, page - 1, size, user)
+    logger.info(`Get sent notifications called by ${user.userId} with request ${JSON.stringify(request)}`)
+    return this.officialVisitsApiClient.searchSentNotifications(prisonId, request, page - 1, size, user)
   }
 
   public async getPrisonTimeSlotById(prisonTimeSlotId: number, user: HmppsUser) {


### PR DESCRIPTION
This refactor goes along with the API refactoring of sent-emails.
API goes in first and UI to follow it.