### PR TITLE
OV-763 : display notification alert on amend visit page when there are changes to visit status and email notifications are enabled

### DIFF
--- a/server/routes/journeys/manage/visit/handlers/amendVisitLandingHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/amendVisitLandingHandler.test.ts
@@ -210,6 +210,19 @@ describe('Search for an official visit', () => {
       )
     })
 
+    it('should render send email alert when hasChanged is true even when email notifications are enabled', async () => {
+      config.featureToggles.emailNotificationsPrisons = 'HEI'
+      officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: true })
+      appSetup()
+
+      const res = await request(app).get(URL)
+      const $ = cheerio.load(res.text)
+
+      expect($('#send-email-button').length).toBe(0)
+      expect($('a[href="/notification/enter-email-address/1/edit"]').length).toBe(1)
+      expect(res.text).toContain('Information about this visit has changed since a confirmation email was last sent')
+    })
+
     it('should handle null visit.updatedBy', () => {
       officialVisitsService.getOfficialVisitById.mockResolvedValue({ ...mockVisitByIdVisit, updatedBy: null })
       return request(app)

--- a/server/routes/journeys/manage/visit/handlers/amendVisitLandingHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/amendVisitLandingHandler.ts
@@ -50,7 +50,7 @@ export default class AmendVisitLandingHandler implements PageHandler {
 
     const visit = await this.officialVisitsService.getOfficialVisitById(Number(ovId), user)
 
-    const [restrictions, prisoner, contacts] = await Promise.all([
+    const [restrictions, prisoner, contacts, visitChangeStatus] = await Promise.all([
       this.personalRelationshipsService.getPrisonerRestrictions(
         visit.prisonerVisited.prisonerNumber,
         0,
@@ -61,6 +61,7 @@ export default class AmendVisitLandingHandler implements PageHandler {
       ),
       this.prisonerService.getPrisonerByPrisonerNumber(visit.prisonerVisited.prisonerNumber, user),
       this.officialVisitsService.getAllContacts(visit.prisonerVisited.prisonerNumber, user),
+      this.officialVisitsService.getVisitChangeStatus(Number(ovId), user),
     ])
 
     const enrichedVisitors = await Promise.all(
@@ -173,6 +174,7 @@ export default class AmendVisitLandingHandler implements PageHandler {
       hasNotApprovedVisitors,
       hasSocialVisitors,
       hasIssueVisitors,
+      hasVisitChanged: visitChangeStatus.hasChanged,
       shouldShowIssues: isFuture(new Date(`${visit.visitDate} ${visit.startTime}`)) && !visit.completionCode,
     })
   }

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -20,7 +20,7 @@
   <h1 class="govuk-heading-l">Official visit</h1>
   {{ miniProfile(prisoner) }}
 
-        {% if user | hasPermission(PERMISSION.MANAGE) and emailNotificationsEnabled and mode != 'amend' and hasVisitChanged and visit.visitStatus in ['CANCELLED', 'SCHEDULED'] %}
+        {% if user | hasPermission(PERMISSION.MANAGE) and emailNotificationsEnabled and hasVisitChanged and visit.visitStatus in ['CANCELLED', 'SCHEDULED'] %}
             {% set notificationPath = "/notification/enter-email-address/" + visit.officialVisitId + ("/cancel" if visit.visitStatus == 'CANCELLED' else "/edit") %}
             {{ mojAlert({
               variant: "warning",


### PR DESCRIPTION
This pull request updates the logic for displaying the "send email" alert on the official visit amendment page, ensuring it appears when visit details have changed, when email notifications are enabled, if a previous notification has been sent.

<img width="1065" height="691" alt="image" src="https://github.com/user-attachments/assets/aae04c80-7710-4e55-8f9b-a47fab8b750d" />
