### PR TITLE
OV-751 clean up exercise adding missing calls to API stubs to clean up wiremock error output. These additions have no effect on tests passing or failing.

### DIFF
--- a/integration_tests/specs/amendVisit.spec.ts
+++ b/integration_tests/specs/amendVisit.spec.ts
@@ -152,6 +152,9 @@ test.describe('Amend official visits', () => {
       contacts: [],
     })
     await personalRelationshipsApi.stubRelationship(1)
+    await personalRelationshipsApi.stubRelationship(2)
+    await personalRelationshipsApi.stubRelationship(3)
+    await personalRelationshipsApi.stubRelationship(999)
   })
 
   test.afterEach(async () => {

--- a/integration_tests/specs/cancelVisits.spec.ts
+++ b/integration_tests/specs/cancelVisits.spec.ts
@@ -64,6 +64,7 @@ test.describe('Cancel an official visit', () => {
     await officialVisitsApi.stubGetOfficialVisitById(mockVisitByIdVisit)
     await officialVisitsApi.stubCompleteVisit({})
     await officialVisitsApi.stubCancelVisit({})
+    await personalRelationshipsApi.stubRelationship(7332364)
   })
 
   test.afterEach(async () => {

--- a/integration_tests/specs/createVisit.spec.ts
+++ b/integration_tests/specs/createVisit.spec.ts
@@ -154,6 +154,8 @@ test.describe('Create an official visit', () => {
       overlappingPrisonerVisits: [],
       contacts: [],
     })
+    await personalRelationshipsApi.stubRelationship(1)
+    await personalRelationshipsApi.stubRelationship(2)
   })
 
   test.afterEach(async () => {

--- a/integration_tests/specs/health.spec.ts
+++ b/integration_tests/specs/health.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test'
-import exampleApi from '../mockApis/exampleApi'
 import hmppsAuth from '../mockApis/hmppsAuth'
 import tokenVerification from '../mockApis/tokenVerification'
 
@@ -53,7 +52,17 @@ test.describe('Health', () => {
 
   test.describe('Some unhealthy', () => {
     test.beforeEach(async () => {
-      await Promise.all([hmppsAuth.stubPing(), exampleApi.stubPing(), tokenVerification.stubPing(500)])
+      await Promise.all([
+        hmppsAuth.stubPing(),
+        tokenVerification.stubPing(500),
+        locationsInsidePrisonApi.stubPing(),
+        prisonApi.stubPing(),
+        personalRelationshipsApi.stubPing(),
+        officialVisitsApi.stubPing(),
+        prisonerSearchApi.stubPing(),
+        activitiesApi.stubPing(),
+        manageUsersApi.stubPing(),
+      ])
     })
 
     test('Health check status is down', async ({ page }) => {


### PR DESCRIPTION
This is purely a wiremock cleanup exercise, this has no bearing on integration tests passing or failing. It cleans up the wiremock error outputs i.e. now there is none.