### PR TITLE
OV-764 : remove print a movement slip button for a cancelled and completed visits

### DIFF
--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
@@ -405,6 +405,7 @@ describe('View an official visit', () => {
           expect(getValueByKey($, 'Search type')).toEqual('Full search')
           expect($('.govuk-button:contains("Amend visit")').length).toBe(0)
           expect($('.govuk-button:contains("Cancel visit")').length).toBe(0)
+          expect($('.govuk-button[href="/view/visit/1/movement-slip"]').length).toBe(0)
         })
     })
 
@@ -431,6 +432,7 @@ describe('View an official visit', () => {
           expect($('.govuk-button:contains("Cancel visit")').length).toBe(0)
           expect(getValueByKey($, 'Completion reason')).toBeNull()
           expect(getValueByKey($, 'Search type')).toBeNull()
+          expect($('.govuk-button[href="/view/visit/1/movement-slip"]').length).toBe(0)
         })
     })
 

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -33,14 +33,16 @@
   {{ unauthorisedVisitorsInset(user, hasIssueVisitors, shouldShowIssues, hasSocialVisitors, hasNotApprovedVisitors, hasNoRelationshipVisitors, PERMISSION) }}
 
   {% if mode != 'amend' %}
-      {{ govukButton({
-      text: "Print movement slip",
-      href: "/view/visit/" + visit.officialVisitId + "/movement-slip",
-      classes: 'govuk-button govuk-button--secondary',
-      attributes: {
-        "target": "_blank"
-      }
-    }) }}
+      {% if visit.visitStatus not in ['COMPLETED', 'CANCELLED'] %}
+          {{ govukButton({
+          text: "Print movement slip",
+          href: "/view/visit/" + visit.officialVisitId + "/movement-slip",
+          classes: 'govuk-button govuk-button--secondary',
+          attributes: {
+            "target": "_blank"
+          }
+        }) }}
+      {% endif %}
        {% if user | hasPermission(PERMISSION.MANAGE) and emailNotificationsEnabled and visit.visitStatus in ['CANCELLED', 'SCHEDULED'] %}
            {{ govukButton({
                id: "send-email-button",


### PR DESCRIPTION
This pull request updates the logic for displaying the "Print movement slip" button on the visit view page. The button will now only be shown for visits that are not in the "COMPLETED" or "CANCELLED" status.