### PR TITLE
OV-791 : fix mini profile restrictions count

### DIFF
--- a/integration_tests/specs/viewVisits.spec.ts
+++ b/integration_tests/specs/viewVisits.spec.ts
@@ -352,6 +352,16 @@ test.describe('View official visits', () => {
     expect(page.url()).toBe('http://localhost:3007/view/visit/1/history')
     await expect(page.locator('.govuk-hint')).toHaveText('Manage existing official visits')
     await expect(page.locator('h1.govuk-heading-l')).toHaveText('Official visit')
+
+    await expect(page.locator('[data-qa="mini-profile-person-profile-link"]')).toHaveText('Doe, John')
+    await expect(page.locator('[data-qa="mini-profile-prisoner-number"]')).toHaveText(mockPrisoner.prisonerNumber)
+    await expect(page.locator('[data-qa="mini-profile-dob"]')).toHaveText('1 June 1989')
+    await expect(page.locator('[data-qa="mini-profile-cell-location"]')).toHaveText(mockPrisoner.cellLocation)
+    await expect(page.locator('[data-qa="mini-profile-prison-name"]')).toHaveText(mockPrisoner.prisonName)
+    await expect(page.locator('[data-qa="contact-A1111AA-alerts-restrictions"]')).toHaveText(
+      /3\s*restrictions\s*and\s*0\s*alerts/,
+    )
+
     await expect(page.locator('.moj-timeline__title').first()).toHaveText('Email notification sent')
     await expect(page.locator('.moj-timeline__title').nth(1)).toHaveText('Visit updated')
     await expect(page.locator('.moj-timeline__title').nth(2)).toHaveText('Email notification failed')

--- a/server/routes/journeys/view/handlers/visitHistoryHandler.test.ts
+++ b/server/routes/journeys/view/handlers/visitHistoryHandler.test.ts
@@ -4,21 +4,35 @@ import * as cheerio from 'cheerio'
 
 import OfficialVisitsService from '../../../../services/officialVisitsService'
 import { appWithAllRoutes, user } from '../../../testutils/appSetup'
-import { mockUser, mockVisitByIdVisit } from '../../../../testutils/mocks'
+import { mockPrisoner, mockPrisonerRestrictions, mockUser, mockVisitByIdVisit } from '../../../../testutils/mocks'
 import { OfficialVisitNotifications } from '../../../../@types/officialVisitsApi/types'
 import ManageUserService from '../../../../services/manageUsersService'
+import PrisonerService from '../../../../services/prisonerService'
+import PersonalRelationshipsService from '../../../../services/personalRelationshipsService'
+import { Prisoner } from '../../../../@types/prisonerSearchApi/types'
+import { getByDataQa, getPageHeader } from '../../../testutils/cheerio'
+import { convertToTitleCase } from '../../../../utils/utils'
 
 jest.mock('../../../../services/officialVisitsService')
 jest.mock('../../../../services/manageUsersService')
+jest.mock('../../../../services/prisonerService')
+jest.mock('../../../../services/personalRelationshipsService')
 
 const officialVisitsService = new OfficialVisitsService(null) as jest.Mocked<OfficialVisitsService>
 const manageUsersService = new ManageUserService(null) as jest.Mocked<ManageUserService>
+const prisonerService = new PrisonerService(null) as jest.Mocked<PrisonerService>
+const personalRelationshipsService = new PersonalRelationshipsService(null) as jest.Mocked<PersonalRelationshipsService>
 
 let app: Express
 
 const appSetup = () => {
   app = appWithAllRoutes({
-    services: { officialVisitsService, manageUsersService },
+    services: {
+      personalRelationshipsService,
+      prisonerService,
+      officialVisitsService,
+      manageUsersService,
+    },
     userSupplier: () => user,
   })
 }
@@ -69,6 +83,8 @@ beforeEach(() => {
       significantChange: true,
     },
   ])
+  personalRelationshipsService.getPrisonerRestrictions.mockResolvedValue({ content: mockPrisonerRestrictions })
+  prisonerService.getPrisonerByPrisonerNumber.mockResolvedValue(mockPrisoner as unknown as Prisoner)
 })
 
 afterEach(() => {
@@ -114,8 +130,19 @@ describe('OfficialVisitHistoryHandler', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
 
-          expect($('.govuk-hint').text().trim()).toBe('Manage existing official visits')
-          expect($('h1.govuk-heading-l').text().trim()).toBe('Official visit')
+          expect($('.govuk-hint').text()).toEqual('Manage existing official visits')
+          expect(getPageHeader($)).toEqual('Official visit')
+
+          expect(getByDataQa($, 'mini-profile-person-profile-link').text().trim()).toEqual(
+            convertToTitleCase(`${mockPrisoner.lastName}, ${mockPrisoner.firstName}`),
+          )
+          expect(getByDataQa($, 'mini-profile-prisoner-number').text().trim()).toEqual(mockPrisoner.prisonerNumber)
+          expect(getByDataQa($, 'mini-profile-dob').text().trim()).toEqual('1 June 1989')
+          expect(getByDataQa($, 'mini-profile-cell-location').text().trim()).toEqual(mockPrisoner.cellLocation)
+          expect(getByDataQa($, 'mini-profile-prison-name').text().trim()).toEqual(mockPrisoner.prisonName)
+          expect(getByDataQa($, 'contact-A1337AA-alerts-restrictions').text().replace(/\s+/g, '')).toEqual(
+            '3restrictionsand0alerts',
+          )
           const title = '.moj-timeline__title'
           expect($(title).eq(0).text().trim()).toBe('Email notification sent')
           expect($(title).eq(1).text().trim()).toBe('Visit updated')

--- a/server/routes/journeys/view/handlers/visitHistoryHandler.ts
+++ b/server/routes/journeys/view/handlers/visitHistoryHandler.ts
@@ -7,6 +7,8 @@ import { AuditedEvent, OfficialVisitNotifications } from '../../../../@types/off
 import { convertToSentenceCase } from '../../../../utils/utils'
 import ManageUserService from '../../../../services/manageUsersService'
 import { HmppsUser } from '../../../../interfaces/hmppsUser'
+import PersonalRelationshipsService from '../../../../services/personalRelationshipsService'
+import PrisonerService from '../../../../services/prisonerService'
 
 type TimelineItem = {
   label: { text: string }
@@ -268,6 +270,8 @@ export default class OfficialVisitHistoryHandler implements PageHandler {
   public PAGE_NAME = Page.OFFICIAL_VISIT_HISTORY_PAGE
 
   constructor(
+    private readonly personalRelationshipsService: PersonalRelationshipsService,
+    private readonly prisonerService: PrisonerService,
     private readonly officialVisitsService: OfficialVisitsService,
     private readonly telemetryService: TelemetryService,
     private readonly manageUsersService: ManageUserService,
@@ -293,6 +297,18 @@ export default class OfficialVisitHistoryHandler implements PageHandler {
       this.officialVisitsService.getNotificationsByOfficialVisitId(visitId, user),
     ])
 
+    const [restrictions, prisoner] = await Promise.all([
+      this.personalRelationshipsService.getPrisonerRestrictions(
+        visit.prisonerVisited.prisonerNumber,
+        0,
+        10,
+        user,
+        true,
+        false,
+      ),
+      this.prisonerService.getPrisonerByPrisonerNumber(visit.prisonerVisited.prisonerNumber, user),
+    ])
+
     const notificationsWithCreators = await resolveNotificationCreators(notifications, this.manageUsersService, user)
 
     const history = buildHistoryTimeline(historyEvents, notificationsWithCreators)
@@ -304,7 +320,12 @@ export default class OfficialVisitHistoryHandler implements PageHandler {
     })
 
     return res.render('pages/view/history', {
-      prisoner: visit.prisonerVisited,
+      prisoner: {
+        ...prisoner,
+        restrictions: restrictions?.content || [],
+        alertsCount: prisoner?.alerts?.filter(alert => alert.active)?.length ?? 0,
+        restrictionsCount: restrictions?.content?.length ?? 0,
+      },
       history,
       backUrl: `/view/visit/${ovId}`,
     })

--- a/server/routes/journeys/view/routes.ts
+++ b/server/routes/journeys/view/routes.ts
@@ -62,7 +62,13 @@ export default function Index({
   route(
     '/visit/:ovId/history',
     Permission.MANAGE,
-    new OfficialVisitHistoryHandler(officialVisitsService, telemetryService, manageUsersService),
+    new OfficialVisitHistoryHandler(
+      personalRelationshipsService,
+      prisonerService,
+      officialVisitsService,
+      telemetryService,
+      manageUsersService,
+    ),
   )
   route('/visit/:ovId/cancel', Permission.MANAGE, new CancelOfficialVisitHandler(officialVisitsService))
   route('/visit/:ovId/movement-slip', Permission.VIEW, new OfficialVisitMovementSlipHandler(officialVisitsService))


### PR DESCRIPTION
The main changes include fetching and rendering prisoner details, restrictions, and alert counts, as well as updating both backend handler logic and frontend tests.
<img width="982" height="473" alt="image" src="https://github.com/user-attachments/assets/73e010d8-d971-4579-a3c5-5ddbc61e30e0" />
