### PR TITLE
OV-785 : make visit_slo a ignored field

### DIFF
--- a/server/routes/journeys/view/handlers/visitHistoryHandler.test.ts
+++ b/server/routes/journeys/view/handlers/visitHistoryHandler.test.ts
@@ -57,6 +57,11 @@ beforeEach(() => {
           oldValue: '14:00',
           newValue: '15:00',
         },
+        {
+          field: 'visit_type',
+          oldValue: 'VIDEO',
+          newValue: 'TELEPHONE',
+        },
       ],
       eventDateTime: '2026-10-25T14:30:00.000000',
       eventUsername: 'JBLOGGS',
@@ -127,6 +132,7 @@ describe('OfficialVisitHistoryHandler', () => {
           expect($(description).text()).toContain('Reason: Email notification for created visit')
           expect($(description).text()).toContain('Visitor added')
           expect($(description).text()).toContain('Visitor updated changed from Joe Bloggs to Jane Bloggs')
+          expect($(description).text()).toContain('Visit Type changed from Video to Telephone')
           expect($(description).text()).toContain('Start Time changed from 14:00 to 15:00')
           expect($(description).text()).toContain('Reason: Email notification for updated visit')
           expect($(description).text()).toContain('Status: Failed')
@@ -200,7 +206,7 @@ describe('OfficialVisitHistoryHandler', () => {
           expect(descriptions.join(' ')).toContain('Reason: Not provided')
           expect(descriptions.join(' ')).toContain('Status: Failed')
           expect(descriptions.join(' ')).toContain('Visitor removed')
-          expect(descriptions.join(' ')).toContain('Visit Slot changed from 11733 to 11679')
+          expect(descriptions.join(' ')).not.toContain('Visit Slot changed from 11733 to 11679')
           expect(descriptions.join(' ')).toContain('Field')
         })
     })

--- a/server/routes/journeys/view/handlers/visitHistoryHandler.test.ts
+++ b/server/routes/journeys/view/handlers/visitHistoryHandler.test.ts
@@ -132,8 +132,8 @@ describe('OfficialVisitHistoryHandler', () => {
           expect($(description).text()).toContain('Reason: Email notification for created visit')
           expect($(description).text()).toContain('Visitor added')
           expect($(description).text()).toContain('Visitor updated changed from Joe Bloggs to Jane Bloggs')
-          expect($(description).text()).toContain('Visit Type changed from Video to Telephone')
-          expect($(description).text()).toContain('Start Time changed from 14:00 to 15:00')
+          expect($(description).text()).toContain('Visit type changed from Video to Telephone')
+          expect($(description).text()).toContain('Start time changed from 14:00 to 15:00')
           expect($(description).text()).toContain('Reason: Email notification for updated visit')
           expect($(description).text()).toContain('Status: Failed')
 

--- a/server/routes/journeys/view/handlers/visitHistoryHandler.ts
+++ b/server/routes/journeys/view/handlers/visitHistoryHandler.ts
@@ -4,7 +4,7 @@ import { PageHandler } from '../../../interfaces/pageHandler'
 import OfficialVisitsService from '../../../../services/officialVisitsService'
 import TelemetryService from '../../../../services/telemetryService'
 import { AuditedEvent, OfficialVisitNotifications } from '../../../../@types/officialVisitsApi/types'
-import { convertToTitleCase } from '../../../../utils/utils'
+import { convertToSentenceCase } from '../../../../utils/utils'
 import ManageUserService from '../../../../services/manageUsersService'
 import { HmppsUser } from '../../../../interfaces/hmppsUser'
 
@@ -84,10 +84,17 @@ const IGNORED_FIELDS = ['visit_slot']
 
 type VisitTypes = 'IN_PERSON' | 'TELEPHONE' | 'VIDEO' | 'UNKNOWN'
 
-const VISIT_TYPES_LABELS_LABELS: Record<VisitTypes, string> = {
+const VISIT_TYPES_LABELS: Record<VisitTypes, string> = {
   IN_PERSON: 'In person',
   TELEPHONE: 'Telephone',
   VIDEO: 'Video',
+  UNKNOWN: NOT_PROVIDED,
+}
+
+type VisitStatus = 'SCHEDULED' | 'CANCELLED' | 'UNKNOWN'
+const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
+  SCHEDULED: 'Scheduled',
+  CANCELLED: 'Cancelled',
   UNKNOWN: NOT_PROVIDED,
 }
 
@@ -123,12 +130,14 @@ const formatFieldName = (field: string): string => {
   const normalizedField = normalizeText(field)?.toLowerCase()
   if (!normalizedField) return DEFAULT_FIELD_LABEL
 
-  const fallbackLabel = convertToTitleCase(normalizedField.replace(/[_-]+/g, ' '))
+  const fallbackLabel = convertToSentenceCase(normalizedField.replace(/[_-]+/g, ' '))
 
   return FIELD_LABELS[normalizedField] ?? (fallbackLabel || DEFAULT_FIELD_LABEL)
 }
 
-const isVisitType = (value: string): value is VisitTypes => value in VISIT_TYPES_LABELS_LABELS
+const isVisitType = (value: string): value is VisitTypes => value in VISIT_TYPES_LABELS
+
+const isVisitStatus = (value: string): value is VisitStatus => value in VISIT_STATUS_LABELS
 
 const formatChange = (field: string, oldValue?: string | null, newValue?: string | null): string => {
   const normalizedField = normalizeText(field)?.toLowerCase() ?? ''
@@ -142,7 +151,10 @@ const formatChange = (field: string, oldValue?: string | null, newValue?: string
       const normalizedPreviousValue = previousValue.toUpperCase()
       const normalizedUpdatedValue = updatedValue.toUpperCase()
       if (isVisitType(normalizedPreviousValue) && isVisitType(normalizedUpdatedValue)) {
-        return `${fieldName} changed from ${VISIT_TYPES_LABELS_LABELS[normalizedPreviousValue]} to ${VISIT_TYPES_LABELS_LABELS[normalizedUpdatedValue]}`
+        return `${fieldName} changed from ${VISIT_TYPES_LABELS[normalizedPreviousValue]} to ${VISIT_TYPES_LABELS[normalizedUpdatedValue]}`
+      }
+      if (isVisitStatus(normalizedPreviousValue) && isVisitStatus(normalizedUpdatedValue)) {
+        return `${fieldName} changed from ${VISIT_STATUS_LABELS[normalizedPreviousValue]} to ${VISIT_STATUS_LABELS[normalizedUpdatedValue]}`
       }
       return `${fieldName} changed from ${previousValue} to ${updatedValue}`
     }

--- a/server/routes/journeys/view/handlers/visitHistoryHandler.ts
+++ b/server/routes/journeys/view/handlers/visitHistoryHandler.ts
@@ -80,6 +80,17 @@ const FIELD_SEMANTICS: Record<string, ChangeSemantics> = {
   visitor_removed: 'removed',
 }
 
+const IGNORED_FIELDS = ['visit_slot']
+
+type VisitTypes = 'IN_PERSON' | 'TELEPHONE' | 'VIDEO' | 'UNKNOWN'
+
+const VISIT_TYPES_LABELS_LABELS: Record<VisitTypes, string> = {
+  IN_PERSON: 'In person',
+  TELEPHONE: 'Telephone',
+  VIDEO: 'Video',
+  UNKNOWN: NOT_PROVIDED,
+}
+
 const isApiNotificationStatus = (value: string): value is ApiNotificationStatus => value in API_TO_USER_STATUS
 
 const isNotificationReason = (value: string): value is NotificationReasonTypes => value in NOTIFICATION_REASON_LABELS
@@ -117,28 +128,49 @@ const formatFieldName = (field: string): string => {
   return FIELD_LABELS[normalizedField] ?? (fallbackLabel || DEFAULT_FIELD_LABEL)
 }
 
+const isVisitType = (value: string): value is VisitTypes => value in VISIT_TYPES_LABELS_LABELS
+
 const formatChange = (field: string, oldValue?: string | null, newValue?: string | null): string => {
+  const normalizedField = normalizeText(field)?.toLowerCase() ?? ''
   const fieldName = formatFieldName(field)
   const previousValue = normalizeText(oldValue)
   const updatedValue = normalizeText(newValue)
-  const semantics = FIELD_SEMANTICS[normalizeText(field)?.toLowerCase() ?? '']
+  const semantics = FIELD_SEMANTICS[normalizedField]
 
-  if (previousValue && updatedValue) return `${fieldName} changed from ${previousValue} to ${updatedValue}`
-  if (semantics === 'added' && updatedValue) return fieldName
-  if (updatedValue) return `${fieldName} set to ${updatedValue}`
-  if (semantics === 'removed' && previousValue) return fieldName
-  if (previousValue) return `${fieldName} removed`
+  if (updatedValue) {
+    if (previousValue) {
+      const normalizedPreviousValue = previousValue.toUpperCase()
+      const normalizedUpdatedValue = updatedValue.toUpperCase()
+      if (isVisitType(normalizedPreviousValue) && isVisitType(normalizedUpdatedValue)) {
+        return `${fieldName} changed from ${VISIT_TYPES_LABELS_LABELS[normalizedPreviousValue]} to ${VISIT_TYPES_LABELS_LABELS[normalizedUpdatedValue]}`
+      }
+      return `${fieldName} changed from ${previousValue} to ${updatedValue}`
+    }
+
+    return semantics === 'added' ? fieldName : `${fieldName} set to ${updatedValue}`
+  }
+
+  if (previousValue) {
+    return semantics === 'removed' ? fieldName : `${fieldName} removed`
+  }
+
   return fieldName
 }
 
 const toTimelineItem = (event: AuditedEvent): TimelineItemWithSort => {
   const timestamp = getTimestamp(event.eventDateTime)
 
+  const removeIgnoredFields = (change: { field: string }) => {
+    const normalizedField = normalizeText(change.field)?.toLowerCase()
+    return !IGNORED_FIELDS.includes(normalizedField ?? '')
+  }
+
   return {
     label: {
       text: withFallback(normalizeText(event.eventSummary), DEFAULT_ACTIVITY_LABEL),
     },
     text: (event.eventChanges ?? [])
+      .filter(removeIgnoredFields)
       .map(change => formatChange(change.field, change.oldValue, change.newValue))
       .join('\n'),
     datetime: {

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -36,6 +36,7 @@ import {
   buildCalendarMonths,
   emailNotificationsEnabled,
   bulkMovementSlipsEnabled,
+  convertToSentenceCase,
 } from './utils'
 import config from '../config'
 import { JourneyVisitor } from '../routes/journeys/manage/visit/journey'
@@ -53,6 +54,22 @@ describe('convert to title case', () => {
     ['Hyphenated', 'Robert-John SmiTH-jONes-WILSON', 'Robert-John Smith-Jones-Wilson'],
   ])('%s convertToTitleCase(%s, %s)', (_: string, a: string, expected: string) => {
     expect(convertToTitleCase(a)).toEqual(expected)
+  })
+})
+
+// sentence case tests here
+describe('convert to sentence case', () => {
+  it.each([
+    [null, null, ''],
+    ['empty string', '', ''],
+    ['Visit', 'Visit', 'Visit'],
+    ['Upper Case', 'VISIT', 'Visit'],
+    ['Multiple words', 'VisIT STATUS', 'Visit status'],
+    ['Leading spaces', '  ViSIT', 'Visit'],
+    ['Trailing spaces', 'VisIT  ', 'Visit'],
+    ['Hyphenated', 'Visit-Status visIT-CanceLLed-AUTO', 'Visit-status visit-cancelled-auto'],
+  ])('%s convertToTitleCase(%s, %s)', (_: string, a: string, expected: string) => {
+    expect(convertToSentenceCase(a)).toEqual(expected)
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -40,6 +40,12 @@ const properCaseName = (name: string): string => (isBlank(name) ? '' : name.spli
 export const convertToTitleCase = (sentence: string): string =>
   isBlank(sentence) ? '' : sentence.split(' ').map(properCaseName).join(' ')
 
+export const convertToSentenceCase = (sentence: string): string => {
+  if (isBlank(sentence)) return ''
+  const trimmedSentence = sentence.trim()
+  return trimmedSentence.charAt(0).toUpperCase() + trimmedSentence.slice(1).toLowerCase()
+}
+
 export const lastNameCommaFirstName = (person: { firstName: string; lastName: string }): string => {
   return `${properCaseName(person.lastName)}, ${properCaseName(person.firstName)}`.replace(/(^, )|(, $)/, '')
 }


### PR DESCRIPTION
The main improvements include user-friendly labels for visit types, filtering out less relevant changes, changing field names to sentence case, and updating tests to reflect these changes.

<img width="460" height="746" alt="image" src="https://github.com/user-attachments/assets/e1005e60-af5c-46b8-8b75-9b185fe31cb7" />
