### PR TITLE
OV-815: Amend -> Update terminology

### DIFF
--- a/integration_tests/specs/amendVisit.spec.ts
+++ b/integration_tests/specs/amendVisit.spec.ts
@@ -91,8 +91,22 @@ const getMockVisit = () => ({
       createdTime: '2023-01-01T00:00:00',
     },
     // Get Chris Smith (not approved visitor)
-    mockOfficialVisitors.find(o => !o.isApprovedVisitor)!,
-    mockSocialVisitors.find(o => !o.isApprovedVisitor)!,
+    ...[mockOfficialVisitors.find(o => !o.isApprovedVisitor)!].map(contact => ({
+      officialVisitorId: contact.prisonerContactId,
+      prisonerContactId: contact.prisonerContactId,
+      contactId: contact.contactId,
+      firstName: contact.firstName,
+      lastName: contact.lastName,
+      relationshipTypeCode: 'OFFICIAL',
+      relationshipTypeDescription: 'Official',
+      relationshipDescription: contact.relationshipToPrisonerDescription,
+      relationshipCode: contact.relationshipToPrisonerCode,
+      visitorTypeCode: 'CONTACT',
+      visitorTypeDescription: 'Contact',
+      leadVisitor: false,
+      createdBy: 'TEST_USER',
+      createdTime: '2023-01-01T00:00:00',
+    })),
   ],
 })
 
@@ -257,9 +271,9 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Change   notes for prisoner (' }).click()
 
     // Amend specific page changes
-    expect(page.locator('h1', { hasText: `Add extra information (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('h1', { hasText: `Add extra information (optional)` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Populated with existing values
     expect(await page.getByRole('textbox', { name: 'Notes for staff' }).textContent()).toEqual('staff notes')
@@ -281,7 +295,7 @@ test.describe('Amend official visits', () => {
 
     await page.getByRole('button', { name: 'Save' }).click()
     expect(page.url()).toBe(`http://localhost:3007/manage/amend/1/${journeyId}`)
-    expect(page.getByRole('region', { name: 'success: Visit amended' }))
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).toBeVisible()
   })
 
   test('should navigate to visit type and visit slot pages when amending visit type', async ({ page }) => {
@@ -292,12 +306,12 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Change   visit type (Visit' }).click()
 
     // Amend specific page changes
-    expect(page.locator('h1', { hasText: `What type of official visit?` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('h1', { hasText: `What type of official visit?` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Pre-selected value
-    expect(page.getByRole('radio', { name: 'Video', exact: true })).toBeChecked()
+    await expect(page.getByRole('radio', { name: 'Video', exact: true })).toBeChecked()
 
     // Back should go back to amend overview page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -317,12 +331,12 @@ test.describe('Amend official visits', () => {
     expect(page.url()).toBe(`http://localhost:3007/manage/amend/1/${journeyId}/time-slot?date=2038-01-01`)
 
     // Amend specific page changes
-    expect(page.locator('h1', { hasText: `Select date and time of official visit` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
-    expect(page.locator('.hmpps-calendar__day--selected')).toBeVisible()
+    await expect(page.locator('h1', { hasText: `Select date and time of official visit` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('.hmpps-calendar__day--selected')).toBeVisible()
     // Pre-selected value
-    expect(page.getByRole('radio', { name: '08:00 to 17:00 First Location' })).toBeChecked()
+    await expect(page.getByRole('radio', { name: '08:00 to 17:00 First Location' })).toBeChecked()
 
     // Back should go back to visit type page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -333,7 +347,7 @@ test.describe('Amend official visits', () => {
     await page.getByRole('radio', { name: '08:00 to 17:00 Second Location' }).check()
     await page.getByRole('button', { name: 'Save' }).click()
 
-    expect(page.getByRole('region', { name: 'success: Visit amended' })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).toBeVisible()
   })
 
   test('should navigate to time slot amend page only when changing time slot', async ({ page }) => {
@@ -344,12 +358,12 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Change   date of visit (Visit' }).click()
 
     // Amend specific page changes
-    expect(page.locator('h1', { hasText: `Select date and time of official visit` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
-    expect(page.locator('.hmpps-calendar__day--selected')).toBeVisible()
+    await expect(page.locator('h1', { hasText: `Select date and time of official visit` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('.hmpps-calendar__day--selected')).toBeVisible()
     // Pre-selected value
-    expect(page.getByRole('radio', { name: '08:00 to 17:00 First Location' })).toBeChecked()
+    await expect(page.getByRole('radio', { name: '08:00 to 17:00 First Location' })).toBeChecked()
 
     // Back should go back to amend overview page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -360,7 +374,7 @@ test.describe('Amend official visits', () => {
     await page.getByRole('radio', { name: '08:00 to 17:00 Second Location' }).check()
     await page.getByRole('button', { name: 'Save' }).click()
 
-    expect(page.getByRole('region', { name: 'success: Visit amended' })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).toBeVisible()
   })
 
   test('should block the amendment and show an error if the visit moves into the past before it is submitted', async ({
@@ -387,7 +401,7 @@ test.describe('Amend official visits', () => {
     await expect(page.getByRole('heading', { name: 'You cannot update this visit' })).toBeVisible()
     await expect(page.getByText('This visit is in the past so you can no longer update it.')).toBeVisible()
 
-    await expect(page.getByRole('region', { name: 'success: Visit amended' })).not.toBeVisible()
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).not.toBeVisible()
   })
 
   test('should navigate to official visitors and show all related pages when "add or remove visitors" is clicked', async ({
@@ -422,11 +436,11 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Add or remove visitors' }).click()
 
     // Verify navigation to visitors page
-    expect(
+    await expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved official contacts list` }),
     ).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to amend overview page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -439,21 +453,21 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Add or remove visitors' }).click()
 
     // Pre-selected value
-    expect(page.getByRole('checkbox', { name: 'Abe Smith' })).toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith' })).not.toBeChecked()
     // Chris Smith should be visible and checked (unapproved but already on the visit)
-    expect(page.getByRole('checkbox', { name: 'Chris Smith' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Chris Smith' })).toBeChecked()
 
     // Select another visitor
     await page.getByRole('checkbox', { name: 'Bertie Smith' }).check()
     await page.getByRole('button', { name: 'Continue' }).click()
 
     // Verify navigation to social visitors page
-    expect(
+    await expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved social contacts list` }),
     ).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to visitors page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -461,19 +475,19 @@ test.describe('Amend official visits', () => {
     await page.goto(`http://localhost:3007/manage/amend/1/${journeyId}/select-social-visitors`)
 
     // Pre-selected value
-    expect(page.getByRole('checkbox', { name: 'Abe Smith' })).toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith' })).not.toBeChecked()
     // Chris Smith should be visible and checked (unapproved but already on the visit)
-    expect(page.getByRole('checkbox', { name: 'Chris Smith' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Chris Smith' })).toBeChecked()
 
     // Select another visitor
     await page.getByRole('checkbox', { name: 'Bertie Smith' }).check()
     await page.getByRole('button', { name: 'Continue' }).click()
 
     // Verify navigation to assistance required page
-    expect(page.locator('h1', { hasText: `Do any visitors need assistance? (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('h1', { hasText: `Do any visitors need assistance? (optional)` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to social visitors page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -481,29 +495,29 @@ test.describe('Amend official visits', () => {
     await page.goBack()
 
     // Pre selected values
-    expect(page.getByRole('checkbox', { name: 'Abe Smith (Solicitor)' })).toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith (Police officer)' })).not.toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Abe Smith (Brother)' })).toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith (Brother)' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith (Solicitor)' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith (Police officer)' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith (Brother)' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith (Brother)' })).not.toBeChecked()
 
     await page.getByRole('button', { name: 'Continue' }).click()
 
-    expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
 
     await page.getByRole('link', { name: 'Back', exact: true }).click()
     expect(page.url()).toBe(`http://localhost:3007/manage/amend/1/${journeyId}/assistance-required`)
     await page.goBack()
 
-    expect(page.getByText('Test assistance notes (official)')).toBeVisible()
-    expect(page.getByText('Test assistance notes (social)')).toBeVisible()
+    await expect(page.getByText('Test assistance notes (official)')).toBeVisible()
+    await expect(page.getByText('Test assistance notes (social)')).toBeVisible()
 
     await page.getByRole('button', { name: 'Continue' }).click()
 
     // Verify navigation to equipment page
-    expect(page.locator('h1', { hasText: `Will visitors have equipment with them? (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('h1', { hasText: `Will visitors have equipment with them? (optional)` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to further visitor details page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -511,15 +525,15 @@ test.describe('Amend official visits', () => {
     await page.goBack()
 
     // Pre selected values
-    expect(page.getByRole('checkbox', { name: 'Abe Smith (Solicitor)' })).toBeChecked()
-    expect(page.getByText('Test equipment (official)')).toBeVisible()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith (Police officer)' })).not.toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Abe Smith (Brother)' })).toBeChecked()
-    expect(page.getByText('Test equipment (social)')).toBeVisible()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith (Brother)' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith (Solicitor)' })).toBeChecked()
+    await expect(page.getByText('Test equipment (official)')).toBeVisible()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith (Police officer)' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith (Brother)' })).toBeChecked()
+    await expect(page.getByText('Test equipment (social)')).toBeVisible()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith (Brother)' })).not.toBeChecked()
 
     await page.getByRole('button', { name: 'Save' }).click()
-    expect(page.getByRole('region', { name: 'success: Visit amended' })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).toBeVisible()
   })
 
   test('should show unauthorised visitor warnings and errors when amending visitors', async ({ page }) => {
@@ -576,7 +590,7 @@ test.describe('Amend official visits', () => {
 
     await page.getByRole('link', { name: 'Add or remove visitors' }).click()
 
-    expect(
+    await expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved official contacts list` }),
     ).toBeVisible()
     await expect(page.getByText('Some visitor details need updating')).toBeVisible()
@@ -599,13 +613,13 @@ test.describe('Amend official visits', () => {
     await page.getByRole('button', { name: 'Continue' }).click()
     await page.getByRole('button', { name: 'Continue' }).click()
 
-    expect(page.locator('h1', { hasText: `Do any visitors need assistance? (optional)` })).toBeVisible()
+    await expect(page.locator('h1', { hasText: `Do any visitors need assistance? (optional)` })).toBeVisible()
     await page.getByRole('button', { name: 'Continue' }).click()
 
-    expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
+    await expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
 
     await page.getByRole('button', { name: 'Save' }).click()
-    expect(page.getByRole('region', { name: 'success: Visit amended' })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).toBeVisible()
   })
 
   test('should navigate to official visitors and show all related pages when "add or remove visitors" is clicked (no equipment)', async ({
@@ -618,11 +632,11 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Add or remove visitors' }).click()
 
     // Verify navigation to visitors page
-    expect(
+    await expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved official contacts list` }),
     ).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to amend overview page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -635,21 +649,21 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Add or remove visitors' }).click()
 
     // Pre-selected value
-    expect(page.getByRole('checkbox', { name: 'Abe Smith' })).toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith' })).not.toBeChecked()
     // Chris Smith should be visible and checked (unapproved but already on the visit)
-    expect(page.getByRole('checkbox', { name: 'Chris Smith' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Chris Smith' })).toBeChecked()
 
     // Select another visitor
     await page.getByRole('checkbox', { name: 'Bertie Smith' }).check()
     await page.getByRole('button', { name: 'Continue' }).click()
 
     // Verify navigation to social visitors page
-    expect(
+    await expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved social contacts list` }),
     ).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to visitors page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -657,17 +671,19 @@ test.describe('Amend official visits', () => {
     await page.goBack()
 
     // Pre-selected value
-    expect(page.getByRole('checkbox', { name: 'Abe Smith' })).toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith' })).not.toBeChecked()
+    // Chris Smith should be visible and checked (unapproved but already on the visit)
+    await expect(page.getByRole('checkbox', { name: 'Chris Smith' })).toBeChecked()
 
     // Select another visitor
     await page.getByRole('checkbox', { name: 'Bertie Smith' }).check()
     await page.getByRole('button', { name: 'Continue' }).click()
 
     // Verify navigation to assistance required page
-    expect(page.locator('h1', { hasText: `Do any visitors need assistance? (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('h1', { hasText: `Do any visitors need assistance? (optional)` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to social visitors page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -675,19 +691,19 @@ test.describe('Amend official visits', () => {
     await page.goBack()
 
     // Pre selected values
-    expect(page.getByRole('checkbox', { name: 'Abe Smith (Solicitor)' })).toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith (Police officer)' })).not.toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Abe Smith (Brother)' })).toBeChecked()
-    expect(page.getByRole('checkbox', { name: 'Bertie Smith (Brother)' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith (Solicitor)' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith (Police officer)' })).not.toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith (Brother)' })).toBeChecked()
+    await expect(page.getByRole('checkbox', { name: 'Bertie Smith (Brother)' })).not.toBeChecked()
 
     await page.getByRole('button', { name: 'Continue' }).click()
 
-    expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
-    expect(page.getByText('Test assistance notes (official)')).toBeVisible()
-    expect(page.getByText('Test assistance notes (social)')).toBeVisible()
+    await expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
+    await expect(page.getByText('Test assistance notes (official)')).toBeVisible()
+    await expect(page.getByText('Test assistance notes (social)')).toBeVisible()
 
     await page.getByRole('button', { name: 'Save' }).click()
-    expect(page.getByRole('region', { name: 'success: Visit amended' })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).toBeVisible()
   })
 
   test('should navigate to Further details page when "change assistance notes" is clicked', async ({ page }) => {
@@ -698,9 +714,9 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Change   notes about the' }).first().click()
 
     // Verify navigation to further visitor details (assistance notes) page
-    expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to Update visit overview page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -708,11 +724,11 @@ test.describe('Amend official visits', () => {
     await page.goBack()
 
     // Pre filled assistance notes
-    expect(page.getByText('Test assistance notes (official)')).toBeVisible()
-    expect(page.getByText('Test assistance notes (social)')).toBeVisible()
+    await expect(page.getByText('Test assistance notes (official)')).toBeVisible()
+    await expect(page.getByText('Test assistance notes (social)')).toBeVisible()
 
     await page.getByRole('button', { name: 'Save' }).click()
-    expect(page.getByRole('region', { name: 'success: Visit amended' })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).toBeVisible()
   })
 
   test('should navigate to equipment page when "change assistance notes" is clicked', async ({ page }) => {
@@ -723,9 +739,9 @@ test.describe('Amend official visits', () => {
     await page.getByRole('link', { name: 'Change   notes about the equipment' }).first().click()
 
     // Verify navigation to assistance required page
-    expect(page.locator('h1', { hasText: `Will visitors have equipment with them? (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
-    expect(page.locator('.moj-progress-bar')).not.toBeVisible()
+    await expect(page.locator('h1', { hasText: `Will visitors have equipment with them? (optional)` })).toBeVisible()
+    await expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
+    await expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to Update visit overview page
     await page.getByRole('link', { name: 'Back', exact: true }).click()
@@ -733,13 +749,13 @@ test.describe('Amend official visits', () => {
     await page.goBack()
 
     // Pre selected values
-    expect(page.getByRole('checkbox', { name: 'Abe Smith (Solicitor)' })).toBeChecked()
-    expect(page.getByText('Test equipment (official)')).toBeVisible()
-    expect(page.getByRole('checkbox', { name: 'Abe Smith (Brother)' })).toBeChecked()
-    expect(page.getByText('Test equipment (social)')).toBeVisible()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith (Solicitor)' })).toBeChecked()
+    await expect(page.getByText('Test equipment (official)')).toBeVisible()
+    await expect(page.getByRole('checkbox', { name: 'Abe Smith (Brother)' })).toBeChecked()
+    await expect(page.getByText('Test equipment (social)')).toBeVisible()
 
     await page.getByRole('button', { name: 'Save' }).click()
-    expect(page.getByRole('region', { name: 'success: Visit amended' })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'success: Visit updated' })).toBeVisible()
   })
 
   test('should cancel and return to visit details', async ({ page }) => {

--- a/integration_tests/specs/amendVisit.spec.ts
+++ b/integration_tests/specs/amendVisit.spec.ts
@@ -258,7 +258,7 @@ test.describe('Amend official visits', () => {
 
     // Amend specific page changes
     expect(page.locator('h1', { hasText: `Add extra information (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Populated with existing values
@@ -293,7 +293,7 @@ test.describe('Amend official visits', () => {
 
     // Amend specific page changes
     expect(page.locator('h1', { hasText: `What type of official visit?` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Pre-selected value
@@ -318,7 +318,7 @@ test.describe('Amend official visits', () => {
 
     // Amend specific page changes
     expect(page.locator('h1', { hasText: `Select date and time of official visit` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
     expect(page.locator('.hmpps-calendar__day--selected')).toBeVisible()
     // Pre-selected value
@@ -345,7 +345,7 @@ test.describe('Amend official visits', () => {
 
     // Amend specific page changes
     expect(page.locator('h1', { hasText: `Select date and time of official visit` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
     expect(page.locator('.hmpps-calendar__day--selected')).toBeVisible()
     // Pre-selected value
@@ -425,7 +425,7 @@ test.describe('Amend official visits', () => {
     expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved official contacts list` }),
     ).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to amend overview page
@@ -452,7 +452,7 @@ test.describe('Amend official visits', () => {
     expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved social contacts list` }),
     ).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to visitors page
@@ -472,7 +472,7 @@ test.describe('Amend official visits', () => {
 
     // Verify navigation to assistance required page
     expect(page.locator('h1', { hasText: `Do any visitors need assistance? (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to social visitors page
@@ -489,7 +489,7 @@ test.describe('Amend official visits', () => {
     await page.getByRole('button', { name: 'Continue' }).click()
 
     expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
 
     await page.getByRole('link', { name: 'Back', exact: true }).click()
     expect(page.url()).toBe(`http://localhost:3007/manage/amend/1/${journeyId}/assistance-required`)
@@ -502,7 +502,7 @@ test.describe('Amend official visits', () => {
 
     // Verify navigation to equipment page
     expect(page.locator('h1', { hasText: `Will visitors have equipment with them? (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to further visitor details page
@@ -621,7 +621,7 @@ test.describe('Amend official visits', () => {
     expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved official contacts list` }),
     ).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to amend overview page
@@ -648,7 +648,7 @@ test.describe('Amend official visits', () => {
     expect(
       page.locator('h1', { hasText: `Select visitors from the prisoner's approved social contacts list` }),
     ).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to visitors page
@@ -666,7 +666,7 @@ test.describe('Amend official visits', () => {
 
     // Verify navigation to assistance required page
     expect(page.locator('h1', { hasText: `Do any visitors need assistance? (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to social visitors page
@@ -699,7 +699,7 @@ test.describe('Amend official visits', () => {
 
     // Verify navigation to further visitor details (assistance notes) page
     expect(page.locator('h1', { hasText: `Further visitor details (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to Update visit overview page
@@ -724,7 +724,7 @@ test.describe('Amend official visits', () => {
 
     // Verify navigation to assistance required page
     expect(page.locator('h1', { hasText: `Will visitors have equipment with them? (optional)` })).toBeVisible()
-    expect(page.locator('.govuk-hint', { hasText: 'Amend an official visit' })).toBeVisible()
+    expect(page.locator('.govuk-hint', { hasText: 'Update an official visit' })).toBeVisible()
     expect(page.locator('.moj-progress-bar')).not.toBeVisible()
 
     // Back should go back to Update visit overview page

--- a/server/routes/journeys/manage/visit/handlers/assistanceRequired.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/assistanceRequired.test.ts
@@ -197,7 +197,7 @@ describe('Assistance required handler', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           const heading = getPageHeader($)
-          expect($('.govuk-hint').eq(0).text()).toEqual('Amend an official visit')
+          expect($('.govuk-hint').eq(0).text()).toEqual('Update an official visit')
           expect(heading).toEqual('Do any visitors need assistance? (optional)')
 
           expect(getArrayItemPropById($, 'assistanceRequired', 0, 'id').val()).toEqual('111')

--- a/server/routes/journeys/manage/visit/handlers/commentsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/commentsHandler.test.ts
@@ -88,7 +88,7 @@ describe('comments handler', () => {
           // There should not be a progress tracker on this page
           expect($('.moj-progress-bar').length).toBeFalsy()
 
-          expect($('.govuk-hint').eq(0).text()).toEqual('Amend an official visit')
+          expect($('.govuk-hint').eq(0).text()).toEqual('Update an official visit')
           expect(heading).toEqual('Add extra information (optional)')
           expect(getTextById($, 'prisonerNotes')).toEqual('Some previously entered notes')
           expect(getTextById($, 'staffNotes')).toEqual('Some previously entered staff notes')

--- a/server/routes/journeys/manage/visit/handlers/commentsHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/commentsHandler.ts
@@ -44,7 +44,7 @@ export default class CommentsHandler implements PageHandler {
         },
         res.locals.user,
       )
-      req.flash('updateVerb', 'amended')
+      req.flash('updateVerb', 'updated')
       return res.redirect(`/manage/amend/${ovId}/${journeyId}`)
     }
 

--- a/server/routes/journeys/manage/visit/handlers/equipmentHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/equipmentHandler.test.ts
@@ -128,7 +128,7 @@ describe('Equipment handler', () => {
           const $ = cheerio.load(res.text)
           const heading = getPageHeader($)
 
-          expect($('.govuk-hint').eq(0).text()).toEqual('Amend an official visit')
+          expect($('.govuk-hint').eq(0).text()).toEqual('Update an official visit')
           expect(heading).toEqual('Will visitors have equipment with them? (optional)')
 
           expect(getArrayItemPropById($, 'equipment', 0, 'id').val()).toEqual('111')
@@ -203,7 +203,7 @@ describe('Equipment handler', () => {
         .send({ equipment: [{ id: '111', notes: 'note' }] })
         .expect(302)
         .expect('location', `/manage/amend/1/${journeyId()}`)
-        .expect(() => expectFlashMessage('updateVerb', 'amended'))
+        .expect(() => expectFlashMessage('updateVerb', 'updated'))
 
       const journeySession = await getJourneySession(app, 'officialVisit')
       expect(journeySession.officialVisitors[0].equipmentNotes).toEqual('note')

--- a/server/routes/journeys/manage/visit/handlers/equipmentHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/equipmentHandler.ts
@@ -65,7 +65,7 @@ export default class EquipmentHandler implements PageHandler {
         { officialVisitors },
         res.locals.user,
       )
-      req.flash('updateVerb', 'amended')
+      req.flash('updateVerb', 'updated')
       return res.redirect(`/manage/amend/${ovId}/${journeyId}`)
     }
     return res.redirect(`comments`)

--- a/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectOfficialVisitorsHandler.test.ts
@@ -367,7 +367,7 @@ describe('Select official visitors', () => {
 
           // Check page header
           const heading = getPageHeader($)
-          expect($('.govuk-hint').text()).toEqual('Amend an official visit')
+          expect($('.govuk-hint').text()).toEqual('Update an official visit')
           expect(heading).toEqual("Select visitors from the prisoner's approved official contacts list")
 
           // Check inset text is displayed with correct bullet points

--- a/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/selectSocialVisitorsHandler.test.ts
@@ -324,7 +324,7 @@ describe('Select social visitors', () => {
 
           // Check page header
           const heading = getPageHeader($)
-          expect($('.govuk-hint').text()).toEqual('Amend an official visit')
+          expect($('.govuk-hint').text()).toEqual('Update an official visit')
           expect(heading).toEqual("Select visitors from the prisoner's approved social contacts list (optional)")
 
           // Check inset text is displayed with bullet points for social visitor and not approved

--- a/server/routes/journeys/manage/visit/handlers/timeSlotHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/timeSlotHandler.test.ts
@@ -195,7 +195,7 @@ describe('Time slot handler', () => {
           const heading = getPageHeader($)
           const selectedDate = getTextById($, 'selected-date')
 
-          expect($('.govuk-hint').text()).toEqual('Amend an official visit')
+          expect($('.govuk-hint').text()).toEqual('Update an official visit')
           expect(heading).toEqual('Select date and time of official visit')
           expect(selectedDate).toEqual('Choose the visit time')
 
@@ -357,7 +357,7 @@ describe('Time slot handler', () => {
         .send({ visitSlot: '1' })
         .expect(302)
         .expect('location', `/manage/amend/1/${journeyId()}`)
-        .expect(() => expectFlashMessage('updateVerb', 'amended'))
+        .expect(() => expectFlashMessage('updateVerb', 'updated'))
     })
 
     it('should surface a visitInPast error when the API rejects amending a past visit', async () => {

--- a/server/routes/journeys/manage/visit/handlers/timeSlotHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/timeSlotHandler.ts
@@ -134,7 +134,7 @@ export default class TimeSlotHandler implements PageHandler {
         },
         res.locals.user,
       )
-      req.flash('updateVerb', 'amended')
+      req.flash('updateVerb', 'updated')
       return res.redirect(`/manage/amend/${ovId}/${journeyId}`)
     }
 

--- a/server/routes/journeys/manage/visit/handlers/visitTypeHandler.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/visitTypeHandler.test.ts
@@ -81,7 +81,7 @@ describe('Visit type handler', () => {
           expect($('.moj-progress-bar').length).toBeFalsy()
           expect($('.govuk-back-link').attr('href')).toEqual(`./`)
 
-          expect($('.govuk-hint').text()).toEqual('Amend an official visit')
+          expect($('.govuk-hint').text()).toEqual('Update an official visit')
           expect(heading).toEqual('What type of official visit?')
 
           // Amend will always show Continue button because it can't update without time-slot

--- a/server/routes/journeys/manage/visit/handlers/visitorDetails.test.ts
+++ b/server/routes/journeys/manage/visit/handlers/visitorDetails.test.ts
@@ -131,7 +131,7 @@ describe('Visitor details handler', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('.govuk-hint').eq(0).text()).toEqual('Amend an official visit')
+          expect($('.govuk-hint').eq(0).text()).toEqual('Update an official visit')
           expect($('.govuk-back-link').attr('href')).toEqual(`./`)
           expect($('.govuk-button').text()).toContain('Save')
         })
@@ -218,7 +218,7 @@ describe('Visitor details handler', () => {
         })
         .expect(302)
         .expect('location', `/manage/amend/1/${journeyId()}`)
-        .expect(() => expectFlashMessage('updateVerb', 'amended'))
+        .expect(() => expectFlashMessage('updateVerb', 'updated'))
 
       expect(officialVisitsService.updateVisitors).toHaveBeenCalledWith(
         'MDI',

--- a/server/routes/journeys/manage/visit/handlers/visitorDetailsHandler.ts
+++ b/server/routes/journeys/manage/visit/handlers/visitorDetailsHandler.ts
@@ -86,7 +86,7 @@ const saveAmendedVisitors = async (req: Request, res: Response, officialVisitsSe
   const ovId = req.params.ovId as string
   const journeyId = req.params.journeyId as string
   await officialVisitsService.updateVisitors(officialVisit.prisonCode, ovId, { officialVisitors }, res.locals.user)
-  req.flash('updateVerb', 'amended')
+  req.flash('updateVerb', 'updated')
   return res.redirect(`/manage/amend/${ovId}/${journeyId}`)
 }
 

--- a/server/views/pages/manage/assistanceRequired.njk
+++ b/server/views/pages/manage/assistanceRequired.njk
@@ -16,7 +16,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Amend'}} an official visit</span>
+      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Update'}} an official visit</span>
       <h1 class="govuk-heading-l">{{pageTitle}} (optional)</h1>
       <form method='POST'>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>

--- a/server/views/pages/manage/comments.njk
+++ b/server/views/pages/manage/comments.njk
@@ -15,7 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Amend'}} an official visit</span>
+      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Update'}} an official visit</span>
       <h1 class="govuk-heading-l">{{ pageTitle }} (optional)</h1>
 
       <form method='POST'>

--- a/server/views/pages/manage/equipment.njk
+++ b/server/views/pages/manage/equipment.njk
@@ -17,7 +17,7 @@
 
   <div class="govuk-grid-row govuk-body">
     <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Amend'}} an official visit</span>
+      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Update'}} an official visit</span>
       <h1 class="govuk-heading-l">{{pageTitle}} (optional)</h1>
       <p>Add any important information about equipment a visitor will bring to the official visit.</p>
       <form method='POST'>

--- a/server/views/pages/manage/selectOfficialVisitors.njk
+++ b/server/views/pages/manage/selectOfficialVisitors.njk
@@ -24,7 +24,7 @@
 
   <div class="govuk-grid-row govuk-body">
     <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Amend'}} an official visit</span>
+      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Update'}} an official visit</span>
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
     </div>
   </div>

--- a/server/views/pages/manage/selectSocialVisitors.njk
+++ b/server/views/pages/manage/selectSocialVisitors.njk
@@ -24,7 +24,7 @@
 
   <div class="govuk-grid-row govuk-body">
     <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Amend'}} an official visit</span>
+      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Update'}} an official visit</span>
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
     </div>
   </div>

--- a/server/views/pages/manage/timeSlot.njk
+++ b/server/views/pages/manage/timeSlot.njk
@@ -21,7 +21,7 @@
 
   <div class="govuk-grid-row govuk-body">
     <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Amend'}} an official visit</span>
+      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Update'}} an official visit</span>
       <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
     </div>
   </div>

--- a/server/views/pages/manage/visitType.njk
+++ b/server/views/pages/manage/visitType.njk
@@ -15,7 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
-      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Amend'}} an official visit</span>
+      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Update'}} an official visit</span>
       <form method='POST'>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 

--- a/server/views/pages/manage/visitorDetails.njk
+++ b/server/views/pages/manage/visitorDetails.njk
@@ -16,7 +16,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Amend'}} an official visit</span>
+      <span class="govuk-hint">{{'Book' if mode == 'create' else 'Update'}} an official visit</span>
       <h1 class="govuk-heading-l">{{pageTitle}} (optional)</h1>
       <p>Add any important information about visitors. Do not include equipment here, you can add this on the next page.</p>
       <form method='POST'>

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -69,8 +69,8 @@
 
   {% if updateVerb %}
       {% set updateVerbTitle = "Visit marked as " + updateVerb %}
-      {% if updateVerb == 'amended' %}
-          {% set updateVerbTitle = "Visit amended" %}
+      {% if updateVerb == 'updated' %}
+          {% set updateVerbTitle = "Visit updated" %}
           {% elif updateVerb == 'cancelled' %}
           {% set updateVerbTitle = "Visit cancelled" %}
       {% endif %}


### PR DESCRIPTION
Journey caption renamed to Update an official visit

<img width="748" height="494" alt="image" src="https://github.com/user-attachments/assets/62a37a08-2a61-4d0b-9b07-3ed70aeecd8b" />

Banner updated

<img width="903" height="662" alt="image" src="https://github.com/user-attachments/assets/0597009a-cc4c-492d-9d8c-7d53f7b38086" />

Plus fixed some outdated assertions that were not awaited (and thus not run)
