### PR TITLE
OV-000: inline cancelled badge with title

### DIFF
--- a/assets/scss/components/_movement-slip.scss
+++ b/assets/scss/components/_movement-slip.scss
@@ -20,7 +20,7 @@
 
 .movement-slip .moj-badge {
   font-size: 0.8rem;
-  margin-bottom: govuk-spacing(2);
+  margin-left: govuk-spacing(2);
 }
 
 .movement-slip {

--- a/server/views/partials/movementSlip.njk
+++ b/server/views/partials/movementSlip.njk
@@ -3,11 +3,8 @@
 
 {% macro movementSlip(visit, prisoner, now, marginBottom = false, headingLevel = 1) %}
   <div class="govuk-grid-row dotted-border govuk-!-padding-top-4 govuk-!-padding-left-4 govuk-!-padding-right-4 govuk-!-padding-bottom-2 movement-slip {% if marginBottom %}govuk-!-margin-bottom-4{% endif %}">
-    <h{{ headingLevel }} class="govuk-body govuk-!-margin-bottom-2"><b>{{ visit.prisonDescription }}</b> Movement authorisation slip</h{{ headingLevel }}>
 
-    {% if visit.visitStatus == 'CANCELLED' %}
-      {{ mojBadge({ text: "Cancelled", classes: "moj-badge--red" }) }}
-    {% endif %}
+    <h{{ headingLevel }} class="govuk-body govuk-!-margin-bottom-2"><b>{{ visit.prisonDescription }}</b> Movement authorisation slip{% if visit.visitStatus == 'CANCELLED' %} {{ mojBadge({ text: "Cancelled", classes: "moj-badge--red" }) }}{% endif %}</h{{ headingLevel }}>
 
     {{ govukSummaryList({
       classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-2',


### PR DESCRIPTION
Cancelled badge is now inline with title rather than underneath - longer prison names will render the badge underneath if theres no enough horizontal space (as before)

<img width="505" height="206" alt="image" src="https://github.com/user-attachments/assets/ab22bd10-5a27-4806-9db0-093eb21febba" />
