### PR TITLE
Ov 803: Timeline content change

### DIFF
--- a/integration_tests/specs/viewVisits.spec.ts
+++ b/integration_tests/specs/viewVisits.spec.ts
@@ -35,27 +35,24 @@ const auditedEvents: AuditedEvent[] = [
   {
     auditedEventId: 1,
     officialVisitId: 1,
+    eventSource: 'DPS',
     eventSummary: 'Visit updated',
     eventType: 'UPDATE',
     eventChanges: [
       {
-        field: 'visitor_removed',
-        newValue: 'Jack Malicious',
+        field: 'start_time',
+        oldValue: '08:00',
+        newValue: '09:00',
       },
       {
-        field: 'visitor_updated',
-        oldValue: 'Peter Malicious',
-        newValue: 'John Smith',
-      },
-      {
-        field: 'visitor_removed',
-        newValue: 'Jack Smith',
+        field: 'end_time',
+        oldValue: '17:00',
+        newValue: '10:00',
       },
     ],
     eventDateTime: '2026-10-25T14:30:00.000000',
     eventUsername: 'AUSER',
     eventUserFullName: 'A User',
-    eventSource: 'DPS',
     eventDetail: 'Visit Updated',
     eventVersion: 2,
     significantChange: true,
@@ -347,7 +344,8 @@ test.describe('View official visits', () => {
       'http://localhost:9091/prisoner/G4793VF/contacts/manage/20085647/relationship/7332364',
     )
 
-    await page.getByRole('button', { name: 'View all changes made for' }).click()
+    // View timeline page
+    await page.getByRole('button', { name: 'View all changes made for visit' }).click()
 
     expect(page.url()).toBe('http://localhost:3007/view/visit/1/history')
     await expect(page.locator('.govuk-hint')).toHaveText('Manage official visits')
@@ -373,8 +371,7 @@ test.describe('View official visits', () => {
     await expect(page.getByText('Email address: visitor@example.com\nReason: Not provided\nStatus: Sent')).toBeVisible()
     await expect(page.getByText('Email address: visitor@example.com Reason: Not provided Status: Failed')).toBeVisible()
     await expect(page.getByText('Visit updated by A User')).toBeVisible()
-    await expect(page.getByText('Visitor removed set to Jack Malicious')).toBeVisible()
-    await expect(page.getByText('Visitor updated changed from Peter Malicious to John Smith')).toBeVisible()
-    await expect(page.getByText('Visitor removed set to Jack Smith')).toBeVisible()
+    await expect(page.getByText('Start time changed from 08:00 to 09:00')).toBeVisible()
+    await expect(page.getByText('End time changed from 17:00 to 10:00')).toBeVisible()
   })
 })

--- a/server/routes/journeys/view/handlers/visitHistoryHandler.test.ts
+++ b/server/routes/journeys/view/handlers/visitHistoryHandler.test.ts
@@ -39,50 +39,9 @@ const appSetup = () => {
 
 beforeEach(() => {
   appSetup()
-
   officialVisitsService.getOfficialVisitById.mockResolvedValue(mockVisitByIdVisit)
   officialVisitsService.getNotificationsByOfficialVisitId.mockResolvedValue([])
-  manageUsersService.getUserByUsername.mockImplementation(async username => ({
-    ...mockUser,
-    name: username,
-    username,
-  }))
-  officialVisitsService.getOfficialVisitAuditedEvents.mockResolvedValue([
-    {
-      auditedEventId: 1,
-      officialVisitId: ovId,
-      eventSummary: 'Visit updated',
-      eventSource: 'DPS',
-      eventDetail:
-        'Visitor added, Visitor updated changed from Joe Bloggs to Jane Bloggs, Start Time changed from 14:00 to 15:00',
-      eventVersion: 2,
-      eventType: 'UPDATE',
-      eventChanges: [
-        {
-          field: 'visitor_added',
-        },
-        {
-          field: 'visitor_updated',
-          oldValue: 'Joe Bloggs',
-          newValue: 'Jane Bloggs',
-        },
-        {
-          field: 'start_time',
-          oldValue: '14:00',
-          newValue: '15:00',
-        },
-        {
-          field: 'visit_type',
-          oldValue: 'VIDEO',
-          newValue: 'TELEPHONE',
-        },
-      ],
-      eventDateTime: '2026-10-25T14:30:00.000000',
-      eventUsername: 'JBLOGGS',
-      eventUserFullName: 'Joe Bloggs',
-      significantChange: true,
-    },
-  ])
+  manageUsersService.getUserByUsername.mockImplementation(async username => ({ ...mockUser, name: username, username }))
   personalRelationshipsService.getPrisonerRestrictions.mockResolvedValue({ content: mockPrisonerRestrictions })
   prisonerService.getPrisonerByPrisonerNumber.mockResolvedValue(mockPrisoner as unknown as Prisoner)
 })
@@ -97,6 +56,40 @@ const URL = `/view/visit/${ovId}/history`
 describe('OfficialVisitHistoryHandler', () => {
   describe('GET', () => {
     it('should render the official visit history timeline', async () => {
+      // Event detail
+      officialVisitsService.getOfficialVisitAuditedEvents.mockResolvedValue([
+        {
+          auditedEventId: 1,
+          officialVisitId: ovId,
+          eventSummary: 'Visit updated',
+          eventSource: 'DPS',
+          eventDetail: 'start_time|14:00|15:00;end_time|15:00|16:00;visit_type|VIDEO|TELEPHONE',
+          eventVersion: 2,
+          eventType: 'UPDATE',
+          eventChanges: [
+            {
+              field: 'start_time',
+              oldValue: '14:00',
+              newValue: '15:00',
+            },
+            {
+              field: 'end_time',
+              oldValue: '15:00',
+              newValue: '16:00',
+            },
+            {
+              field: 'visit_type',
+              oldValue: 'VIDEO',
+              newValue: 'TELEPHONE',
+            },
+          ],
+          eventDateTime: '2026-10-25T14:30:00.000000',
+          eventUsername: 'JBLOGGS',
+          eventUserFullName: 'Joe Bloggs',
+          significantChange: true,
+        },
+      ])
+
       officialVisitsService.getNotificationsByOfficialVisitId.mockResolvedValue([
         {
           notificationId: 2,
@@ -157,10 +150,9 @@ describe('OfficialVisitHistoryHandler', () => {
           const description = '.moj-timeline__description'
           expect($(description).text()).toContain('Email address: visitor@example.com')
           expect($(description).text()).toContain('Reason: Email notification for created visit')
-          expect($(description).text()).toContain('Visitor added')
-          expect($(description).text()).toContain('Visitor updated changed from Joe Bloggs to Jane Bloggs')
           expect($(description).text()).toContain('Visit type changed from Video to Telephone')
           expect($(description).text()).toContain('Start time changed from 14:00 to 15:00')
+          expect($(description).text()).toContain('End time changed from 15:00 to 16:00')
           expect($(description).text()).toContain('Reason: Email notification for updated visit')
           expect($(description).text()).toContain('Status: Failed')
 
@@ -175,14 +167,14 @@ describe('OfficialVisitHistoryHandler', () => {
         {
           auditedEventId: 5,
           officialVisitId: ovId,
-          eventSummary: '   ',
+          eventSummary: ' Visitor changed  ',
           eventType: 'UPDATE',
           eventSource: 'DPS',
-          eventDetail:
-            'Visitor added, Visitor updated changed from Joe Bloggs to Jane Bloggs, Start Time changed from 14:00 to 15:00',
+          eventDetail: 'visitor_updated||James Peters;visitor_removed||John Smith;',
           eventVersion: 2,
           eventChanges: [
-            { field: 'visitor_removed', oldValue: '  John Smith  ' },
+            { field: 'visitor_removed', oldValue: null, newValue: '  John Smith  ' },
+            { field: 'visitor_updated', oldValue: null, newValue: 'James Peters' },
             { field: 'visit_slot', oldValue: '11733', newValue: '11679' },
             { field: '   ', oldValue: '   ', newValue: '   ' },
           ],
@@ -225,15 +217,20 @@ describe('OfficialVisitHistoryHandler', () => {
             .map((_index, element) => $(element).text())
             .get()
 
-          expect(titles).toEqual(expect.arrayContaining(['Email notification failed', 'Activity updated']))
+          expect(titles).toEqual(expect.arrayContaining(['Email notification failed', 'Visitors updated']))
           expect(bylines[0]).toContain('by System')
           expect(bylines[1]).toContain('System')
           expect(dates).toEqual(expect.arrayContaining(['1 January 1970 at 00:00']))
           expect(descriptions.join(' ')).toContain('Email address: Not provided')
           expect(descriptions.join(' ')).toContain('Reason: Not provided')
           expect(descriptions.join(' ')).toContain('Status: Failed')
-          expect(descriptions.join(' ')).toContain('Visitor removed')
-          expect(descriptions.join(' ')).not.toContain('Visit Slot changed from 11733 to 11679')
+          expect(descriptions.join(' ')).toContain('Visitor John Smith removed from visit')
+          expect(descriptions.join(' ')).toContain('Visitor James Peters reviewed and retained')
+
+          // This is configured as an ignored change field - not reported on timeline
+          expect(descriptions.join(' ')).not.toContain('Visit slot changed from 11733 to 11679')
+
+          // Unknow field - defaults the field name to Field
           expect(descriptions.join(' ')).toContain('Field')
         })
     })

--- a/server/routes/journeys/view/handlers/visitHistoryHandler.ts
+++ b/server/routes/journeys/view/handlers/visitHistoryHandler.ts
@@ -101,7 +101,13 @@ const normalizeText = (value?: string | null): string | undefined => {
   return trimmed || undefined
 }
 
-const withFallback = (value: string | undefined, fallback: string): string => value ?? fallback
+const withFallback = (value: string | undefined, fallback: string): string => {
+  // TODO - change this event summary in the API from 'Visitor changed' to 'Visitors updated'
+  if (value === 'Visitor changed') {
+    return 'Visitors updated'
+  }
+  return value ?? fallback
+}
 
 const getTimestamp = (value?: string | null): string => withFallback(normalizeText(value), DEFAULT_TIMESTAMP)
 
@@ -140,6 +146,23 @@ const formatChange = (field: string, oldValue?: string | null, newValue?: string
   const updatedValue = normalizeText(newValue)
   const semantics = FIELD_SEMANTICS[normalizedField]
 
+  // Deal with visitor changes first
+  // TODO: Consider whether reviewed and retained is the right wording here
+  // Can't ignore updates - or we risk an empty timeline event - but nor do we have the detail changes per visitor yet
+  if (['Visitor added', 'Visitor updated', 'Visitor removed'].includes(fieldName)) {
+    switch (fieldName) {
+      case 'Visitor added':
+        return `Visitor ${updatedValue} added to visit`
+      case 'Visitor removed':
+        return `Visitor ${updatedValue} removed from visit`
+      case 'Visitor updated':
+        return `Visitor ${updatedValue} reviewed and retained`
+      default:
+        return `Unknown visitor event`
+    }
+  }
+
+  // Attempt more generic stuff - which didn't work for visitor changes, but does for visit field-level changes
   if (updatedValue) {
     if (previousValue) {
       const normalizedPreviousValue = previousValue.toUpperCase()


### PR DESCRIPTION
This is short-term fix to get it working and in front of users.

However, I want to revisit this to simplify the UI timeline code, and provide more data in audited events for the visitor changes, so we know what (specifically) changed, if anything, for a visitor during an update visitor operation.

Test tests were checking for responses which weren't actually possible, so I've altered these too.

I've marked the code areas with a TODO label, so I can find them again.

OLD VERSION

<img width="677" height="775" alt="image" src="https://github.com/user-attachments/assets/b8f45800-4233-4499-b33d-0f35b0a8a933" />

NEW VERSION

<img width="677" height="775" alt="image" src="https://github.com/user-attachments/assets/eded2255-cc91-4496-8556-c32b0c46dc28" />
