### PR TITLE
OV-839 : Visit update success banner

### DIFF
--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import OfficialVisitsService from '../../../../services/officialVisitsService'
 import PrisonerService from '../../../../services/prisonerService'
-import { appWithAllRoutes, user } from '../../../testutils/appSetup'
+import { appWithAllRoutes, flashProvider, user } from '../../../testutils/appSetup'
 import { mockPrisoner, mockVisitByIdVisit, mockPrisonerRestrictions, mockUser } from '../../../../testutils/mocks'
 import AuditService, { Page } from '../../../../services/auditService'
 import { getByDataQa, getPageHeader, getValueByKey } from '../../../testutils/cheerio'
@@ -218,6 +218,41 @@ describe('View an official visit', () => {
       expect($('#send-email-button').attr('target')).toBeUndefined()
       expect(res.text).toContain('Information about this visit has changed since a confirmation email was last sent')
       expect($('.moj-alert a.govuk-link').attr('href')).toEqual('/notification/enter-email-address/1/edit')
+    })
+
+    it('should render updated success alert with bullet point actions when updateVerb is updated and feature is enabled', async () => {
+      config.featureToggles.emailNotificationsPrisons = 'HEI'
+      officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: false })
+      appSetup([AuthorisedRoles.MANAGE])
+      flashProvider.mockImplementation((key: string) => (key === 'updateVerb' ? ['updated'] : []))
+
+      const res = await request(app).get(URL)
+      const $ = cheerio.load(res.text)
+      const alert = $('.moj-alert')
+
+      expect(alert.text()).toContain('Visit updated')
+      expect(alert.find('ul.govuk-list.govuk-list--bullet').length).toBe(1)
+      expect(alert.find('ul.govuk-list.govuk-list--bullet li').length).toBe(2)
+      expect(alert.find('a[href="/notification/enter-email-address/1/edit"]').text()).toContain(
+        'send updated email confirmation',
+      )
+      expect(alert.find('a[href="/view/list"]').text()).toContain('return to search list')
+    })
+
+    it('should not render updated success alert with bullet point actions when updateVerb is updated and feature is disabled', async () => {
+      flashProvider.mockImplementation((key: string) => (key === 'updateVerb' ? ['updated'] : []))
+
+      const res = await request(app).get(URL)
+      const $ = cheerio.load(res.text)
+      const alert = $('.moj-alert')
+
+      expect(alert.text()).toContain('Visit updated')
+      expect(alert.find('ul.govuk-list.govuk-list--bullet').length).toBe(0)
+      expect(alert.find('ul.govuk-list.govuk-list--bullet li').length).toBe(0)
+      expect(alert.find('a[href="/notification/enter-email-address/1/edit"]').text()).not.toContain(
+        'send updated email confirmation',
+      )
+      expect(alert.find('a[href="/view/list"]').text()).toContain('Return to search list')
     })
 
     it('should not render send email alert when email notifications are enabled but hasChanged is false', async () => {

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -67,11 +67,23 @@
     {{ mojBadge({ text: badgeText, classes: "moj-badge--red govuk-!-margin-bottom-4" }) }}
   {% endif %}
 
-  {% if updateVerb %}
+     {% if updateVerb %}
       {% set updateVerbTitle = "Visit marked as " + updateVerb %}
+      {% set updatAlertHtml = "You have " + updateVerb + " this visit. <a href='" + (amendedBackUrl or backUrl or '/view/list') + "'>Return to search list</a>" %}
       {% if updateVerb == 'updated' %}
           {% set updateVerbTitle = "Visit updated" %}
-          {% elif updateVerb == 'cancelled' %}
+          {% if user | hasPermission(PERMISSION.MANAGE) and emailNotificationsEnabled and visit.visitStatus in ['CANCELLED', 'SCHEDULED'] %}
+              {% set updatAlertHtml = "<p class='govuk-body'>You have " + updateVerb + " this visit. You can:</p>
+              <ul class='govuk-list govuk-list--bullet'>
+                <li class='govuk-!-margin-bottom-2'>
+                  <a href='/notification/enter-email-address/" + visit.officialVisitId + "/edit'>send updated email confirmation</a>
+                </li>
+                <li class='govuk-!-margin-bottom-2'>
+                  <a href='" + (amendedBackUrl or backUrl or '/view/list') + "'>return to search list</a>
+                </li>
+              </ul>" %}
+          {% endif %}
+      {% elif updateVerb == 'cancelled' %}
           {% set updateVerbTitle = "Visit cancelled" %}
       {% endif %}
     {{ mojAlert({
@@ -79,7 +91,7 @@
       title: updateVerbTitle,
       showTitleAsHeading: true,
       dismissible: false,
-      html: "You have " + updateVerb + " this visit. <a href='" + (amendedBackUrl or backUrl or '/view/list') + "'>Return to search list</a>"
+      html: updatAlertHtml
     }) }}
 
   {% endif %}


### PR DESCRIPTION
This pull request adds a success alert shown after an official visit is updated. Now, when certain conditions are met (such as permissions and feature flags), the alert includes bullet-pointed actions to guide the user.

When the feature and permission is set, 
<img width="965" height="525" alt="image" src="https://github.com/user-attachments/assets/0b55cd69-73d4-4959-9248-474cfe007ba6" />

When the email notification feature is disabled.
<img width="959" height="471" alt="image" src="https://github.com/user-attachments/assets/73e40db7-0bb1-42c4-ae26-83ee682cf66a" />


