### PR TITLE
OV-840: Visit cancelled success banner updates

### DIFF
--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -92,9 +92,3 @@
 .moj-timeline__description {
   white-space: pre-line;
 }
-
-// Links in success alerts use the standard link colours rather than the
-// component's green
-.moj-alert--success .moj-alert__content a {
-  @include govuk-link-style-default;
-}

--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -92,3 +92,9 @@
 .moj-timeline__description {
   white-space: pre-line;
 }
+
+// Links in success alerts use the standard link colours rather than the
+// component's green
+.moj-alert--success .moj-alert__content a {
+  @include govuk-link-style-default;
+}

--- a/integration_tests/mockApis/officialVisitsApi.ts
+++ b/integration_tests/mockApis/officialVisitsApi.ts
@@ -86,8 +86,8 @@ export default {
     simplePostApiMock(`/official-visits-api/official-visit/prison/LEI`, response),
   stubCompleteVisit: (response: RecursivePartial<CompleteVisitRequest>) =>
     simplePostApiMock(`/official-visits-api/official-visit/prison/LEI/id/\\d+/complete`, response),
-  stubCancelVisit: (response: RecursivePartial<CancelTypeRequest>) =>
-    simplePostApiMock(`/official-visits-api/official-visit/prison/LEI/id/\\d+/cancel`, response),
+  stubCancelVisit: (response: RecursivePartial<CancelTypeRequest>, prisonCode = 'LEI') =>
+    simplePostApiMock(`/official-visits-api/official-visit/prison/${prisonCode}/id/\\d+/cancel`, response),
   stubUpdateVisitors: (prisonCode: string, visitId: string) =>
     stubFor({
       request: {

--- a/integration_tests/specs/cancelVisits.spec.ts
+++ b/integration_tests/specs/cancelVisits.spec.ts
@@ -18,7 +18,9 @@ import {
 } from '../../server/testutils/mocks'
 import ViewVisitPage from '../pages/viewVisitPage'
 import CancelVisitPage from '../pages/cancelVisitPage'
+import NotificationEmailPage from '../pages/notificationEmailPage'
 import { completionCodes, locations, mockPrisoner, searchLevels, statuses, visitTypes } from '../mockData/data'
+import { OfficialVisitNotifications } from '../../server/@types/officialVisitsApi/types'
 
 test.describe('Cancel an official visit', () => {
   test.beforeEach(async () => {
@@ -102,5 +104,68 @@ test.describe('Cancel an official visit', () => {
     await expect(page.getByRole('region', { name: 'success: Visit cancelled' })).toBeVisible()
     await expect(page.getByText('You have cancelled this visit.')).toBeVisible()
     await expect(page.getByRole('link', { name: 'Return to search list' })).toBeVisible()
+  })
+
+  test('Success banner shows email confirmation actions when email notifications are enabled', async ({ page }) => {
+    await officialVisitsApi.getNotificationsByOfficialVisitId(1, [
+      { emailAddress: 'visitor@example.com' },
+    ] as OfficialVisitNotifications)
+
+    await login(page)
+    await page.goto(`/view/list`)
+    const visitListPage = await ListVisitsPage.verifyOnPage(page)
+    await visitListPage.page.getByRole('link', { name: 'Select' }).first().click()
+    await ViewVisitPage.verifyOnPage(page)
+
+    await page.getByRole('link', { name: 'Cancel visit' }).click()
+    await CancelVisitPage.verifyOnPage(page)
+    await page.getByRole('radio', { name: 'Cancelled by visitor' }).click()
+
+    await officialVisitsApi.stubGetOfficialVisitById({
+      ...mockVisitByIdVisit,
+      visitStatus: 'CANCELLED',
+      visitStatusDescription: 'Cancelled',
+    })
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    const banner = page.getByRole('region', { name: 'success: Visit cancelled' })
+    await expect(banner).toBeVisible()
+    await expect(banner.getByText('You have cancelled this visit. You can:')).toBeVisible()
+    const emailLink = banner.getByRole('link', { name: 'send updated email confirmation' })
+    await expect(emailLink).toHaveAttribute('href', '/notification/enter-email-address/1/cancel')
+    await expect(banner.getByRole('link', { name: 'return to search list' })).toBeVisible()
+
+    await emailLink.click()
+    const emailPage = await NotificationEmailPage.verifyOnPage(page)
+    await expect(page).toHaveURL('/notification/enter-email-address/1/cancel')
+    await expect(emailPage.emailInput).toHaveValue('visitor@example.com')
+  })
+
+  test('Success banner shows plain return link when email notifications are disabled for the prison', async ({
+    page,
+  }) => {
+    await componentsApi.stubComponents('BXI', 'Brixton (HMP)')
+    await officialVisitsApi.stubCancelVisit({}, 'BXI')
+
+    await login(page)
+    await page.goto('/view/visit/1')
+    await expect(page.locator('h1', { hasText: 'Official visit' })).toBeVisible()
+    await expect(page.locator('#send-email-button')).toHaveCount(0)
+
+    await page.getByRole('link', { name: 'Cancel visit' }).click()
+    await CancelVisitPage.verifyOnPage(page)
+    await page.getByRole('radio', { name: 'Cancelled by visitor' }).click()
+
+    await officialVisitsApi.stubGetOfficialVisitById({
+      ...mockVisitByIdVisit,
+      visitStatus: 'CANCELLED',
+      visitStatusDescription: 'Cancelled',
+    })
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    const banner = page.getByRole('region', { name: 'success: Visit cancelled' })
+    await expect(banner).toBeVisible()
+    await expect(banner.getByRole('link', { name: 'send updated email confirmation' })).toHaveCount(0)
+    await expect(banner.getByRole('link', { name: 'Return to search list', exact: true })).toBeVisible()
   })
 })

--- a/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
+++ b/server/routes/journeys/view/handlers/viewOfficialVisitHandler.test.ts
@@ -255,6 +255,49 @@ describe('View an official visit', () => {
       expect(alert.find('a[href="/view/list"]').text()).toContain('Return to search list')
     })
 
+    it('should render cancelled success alert with bullet point actions when updateVerb is cancelled and feature is enabled', async () => {
+      config.featureToggles.emailNotificationsPrisons = 'HEI'
+      officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: false })
+      officialVisitsService.getOfficialVisitById.mockResolvedValue({
+        ...mockVisitByIdVisit,
+        visitStatus: 'CANCELLED',
+        visitStatusDescription: 'Cancelled',
+      })
+      appSetup([AuthorisedRoles.MANAGE])
+      flashProvider.mockImplementation((key: string) => (key === 'updateVerb' ? ['cancelled'] : []))
+
+      const res = await request(app).get(URL)
+      const $ = cheerio.load(res.text)
+      const alert = $('.moj-alert')
+
+      expect(alert.text()).toContain('Visit cancelled')
+      expect(alert.text()).toContain('You have cancelled this visit. You can:')
+      expect(alert.find('ul.govuk-list.govuk-list--bullet').length).toBe(1)
+      expect(alert.find('ul.govuk-list.govuk-list--bullet li').length).toBe(2)
+      expect(alert.find('a[href="/notification/enter-email-address/1/cancel"]').text()).toContain(
+        'send updated email confirmation',
+      )
+      expect(alert.find('a[href="/view/list"]').text()).toContain('return to search list')
+    })
+
+    it('should not render cancelled success alert with bullet point actions when updateVerb is cancelled and feature is disabled', async () => {
+      officialVisitsService.getOfficialVisitById.mockResolvedValue({
+        ...mockVisitByIdVisit,
+        visitStatus: 'CANCELLED',
+        visitStatusDescription: 'Cancelled',
+      })
+      flashProvider.mockImplementation((key: string) => (key === 'updateVerb' ? ['cancelled'] : []))
+
+      const res = await request(app).get(URL)
+      const $ = cheerio.load(res.text)
+      const alert = $('.moj-alert')
+
+      expect(alert.text()).toContain('Visit cancelled')
+      expect(alert.find('ul.govuk-list.govuk-list--bullet').length).toBe(0)
+      expect(alert.find('a[href="/notification/enter-email-address/1/cancel"]').length).toBe(0)
+      expect(alert.find('a[href="/view/list"]').text()).toContain('Return to search list')
+    })
+
     it('should not render send email alert when email notifications are enabled but hasChanged is false', async () => {
       config.featureToggles.emailNotificationsPrisons = 'HEI'
       officialVisitsService.getVisitChangeStatus.mockResolvedValue({ hasChanged: false })

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -67,31 +67,31 @@
     {{ mojBadge({ text: badgeText, classes: "moj-badge--red govuk-!-margin-bottom-4" }) }}
   {% endif %}
 
-     {% if updateVerb %}
+  {% if updateVerb %}
       {% set updateVerbTitle = "Visit marked as " + updateVerb %}
-      {% set updatAlertHtml = "You have " + updateVerb + " this visit. <a href='" + (amendedBackUrl or backUrl or '/view/list') + "'>Return to search list</a>" %}
+      {% set updateAlertHtml = "You have " + updateVerb + " this visit. <a href='" + (amendedBackUrl or backUrl or '/view/list') + "'>Return to search list</a>" %}
       {% if updateVerb == 'updated' %}
           {% set updateVerbTitle = "Visit updated" %}
-          {% if user | hasPermission(PERMISSION.MANAGE) and emailNotificationsEnabled and visit.visitStatus in ['CANCELLED', 'SCHEDULED'] %}
-              {% set updatAlertHtml = "<p class='govuk-body'>You have " + updateVerb + " this visit. You can:</p>
-              <ul class='govuk-list govuk-list--bullet'>
-                <li class='govuk-!-margin-bottom-2'>
-                  <a href='/notification/enter-email-address/" + visit.officialVisitId + "/edit'>send updated email confirmation</a>
-                </li>
-                <li class='govuk-!-margin-bottom-2'>
-                  <a href='" + (amendedBackUrl or backUrl or '/view/list') + "'>return to search list</a>
-                </li>
-              </ul>" %}
-          {% endif %}
       {% elif updateVerb == 'cancelled' %}
           {% set updateVerbTitle = "Visit cancelled" %}
+      {% endif %}
+      {% if updateVerb in ['updated', 'cancelled'] and user | hasPermission(PERMISSION.MANAGE) and emailNotificationsEnabled and visit.visitStatus in ['CANCELLED', 'SCHEDULED'] %}
+          {% set updateAlertHtml = "<p class='govuk-body'>You have " + updateVerb + " this visit. You can:</p>
+          <ul class='govuk-list govuk-list--bullet'>
+            <li class='govuk-!-margin-bottom-2'>
+              <a href='/notification/enter-email-address/" + visit.officialVisitId + ("/cancel" if visit.visitStatus == 'CANCELLED' else "/edit") + "'>send updated email confirmation</a>
+            </li>
+            <li class='govuk-!-margin-bottom-2'>
+              <a href='" + (amendedBackUrl or backUrl or '/view/list') + "'>return to search list</a>
+            </li>
+          </ul>" %}
       {% endif %}
     {{ mojAlert({
       variant: "success",
       title: updateVerbTitle,
       showTitleAsHeading: true,
       dismissible: false,
-      html: updatAlertHtml
+      html: updateAlertHtml
     }) }}
 
   {% endif %}

--- a/server/views/pages/view/visit.njk
+++ b/server/views/pages/view/visit.njk
@@ -76,7 +76,7 @@
           {% set updateVerbTitle = "Visit cancelled" %}
       {% endif %}
       {% if updateVerb in ['updated', 'cancelled'] and user | hasPermission(PERMISSION.MANAGE) and emailNotificationsEnabled and visit.visitStatus in ['CANCELLED', 'SCHEDULED'] %}
-          {% set updateAlertHtml = "<p class='govuk-body'>You have " + updateVerb + " this visit. You can:</p>
+          {% set updateAlertHtml = "<p class='govuk-body govuk-!-margin-bottom-1'>You have " + updateVerb + " this visit. You can:</p>
           <ul class='govuk-list govuk-list--bullet'>
             <li class='govuk-!-margin-bottom-2'>
               <a href='/notification/enter-email-address/" + visit.officialVisitId + ("/cancel" if visit.visitStatus == 'CANCELLED' else "/edit") + "'>send updated email confirmation</a>


### PR DESCRIPTION
Feature toggle OFF
<img width="1280" height="1000" alt="e2e-cancelled-banner-feature-off" src="https://github.com/user-attachments/assets/cd68183a-1984-4564-9161-f55bd137bf45" />

Feature toggle ON
<img width="1280" height="1000" alt="e2e-cancelled-banner-feature-on" src="https://github.com/user-attachments/assets/b70c6b2e-55a5-42e7-8ec7-ff9ea9c95b16" />

Updated:
<img width="1204" height="780" alt="image" src="https://github.com/user-attachments/assets/f55aca37-2817-4b9d-bd26-b72990d9cea5" />

